### PR TITLE
Use single dispatch for databroker getitem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ install:
   # conda-forge is activated on metadatastore, filestore and channelarchiver
   # - conda config --add channels lightsource2-dev
   # - conda install -n testenv metadatastore filestore channelarchiver
+  - if [ $TRAVIS_PYTHON_VERSION = "2.7" ]; then
+      pip install singledispatch;
+    fi;
   - pip install https://github.com/NSLS-II/metadatastore/zipball/master#egg=metadatastore
   - pip install https://github.com/NSLS-II/filestore/zipball/master#egg=filestore
   - pip install https://github.com/NSLS-II/channelarchiver/zipball/master#egg=channelarchiver

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - channelarchiver
     - six
     - tzlocal
+    - singledispatch [py26 or py27 or py33]
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - channelarchiver
     - six
     - tzlocal
-    - singledispatch [py26 or py27 or py33]
+    - singledispatch [py27]
 
 test:
   requires:

--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -6,7 +6,7 @@ __all__ = ['DataBroker', 'get_images', 'get_events', 'get_table']
 
 
 # generally useful imports
-from .databroker import DataBroker, get_events, get_table
+from .databroker import DataBroker, get_events, get_table, search
 from .pims_readers import get_images
 from .handler_registration import register_builtin_handlers
 

--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -6,7 +6,8 @@ __all__ = ['DataBroker', 'get_images', 'get_events', 'get_table']
 
 
 # generally useful imports
-from .databroker import DataBroker, get_events, get_table, search
+from .databroker import (DataBroker, DataBroker as db,
+                         get_events, get_table, search)
 from .pims_readers import get_images
 from .handler_registration import register_builtin_handlers
 

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -25,7 +25,11 @@ except ImportError:
         )
 
 import numbers
-from collections import abc
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    # This will error on python < 3.3
+    from collections import MutableSequence
 
 
 logger = logging.getLogger(__name__)
@@ -118,7 +122,7 @@ def _(key):
 
 @search.register(set)
 @search.register(tuple)
-@search.register(abc.MutableSequence)
+@search.register(MutableSequence)
 def _(key):
     return [search(k) for k in key]
 

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -11,7 +11,18 @@ import metadatastore.doc as doc
 import metadatastore.commands as mc
 import filestore.api as fs
 import logging
-from functools import singledispatch
+try:
+    from functools import singledispatch
+except ImportError:
+    try:
+        # We are running on Python 2.6, 2.7, or 3.3
+        import singledispatch
+    except ImportError:
+        print("Please install singledispatch from PyPI"
+              "\n\n   pip install single dispatch"
+              "\n\nThen run your program again.")
+        raise
+
 import numbers
 from collections import abc
 

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -18,10 +18,11 @@ except ImportError:
         # We are running on Python 2.6, 2.7, or 3.3
         import singledispatch
     except ImportError:
-        print("Please install singledispatch from PyPI"
-              "\n\n   pip install single dispatch"
-              "\n\nThen run your program again.")
-        raise
+        raise ImportError(
+            "Please install singledispatch from PyPI"
+            "\n\n   pip install singledispatch"
+            "\n\nThen run your program again."
+        )
 
 import numbers
 from collections import abc

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -11,20 +11,21 @@ import metadatastore.doc as doc
 import metadatastore.commands as mc
 import filestore.api as fs
 import logging
+import numbers
+
+
 try:
     from functools import singledispatch
 except ImportError:
     try:
         # We are running on Python 2.6, 2.7, or 3.3
-        import singledispatch
+        from singledispatch import singledispatch
     except ImportError:
         raise ImportError(
             "Please install singledispatch from PyPI"
             "\n\n   pip install singledispatch"
             "\n\nThen run your program again."
         )
-
-import numbers
 try:
     from collections.abc import MutableSequence
 except ImportError:

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -100,6 +100,11 @@ def _(key):
 
 
 @search.register(str)
+@search.register(six.text_type)
+# py2: six.string_types = (basestring,)
+# py3: six.string_types = (str,)
+# so we need to just grab the only element out of this
+@search.register(six.string_types,)
 def _(key):
     logger.info('Interpreting key = %s as a str' % key)
     results = None

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -39,6 +39,7 @@ TZ = str(tzlocal.get_localzone())
 
 @singledispatch
 def search(key):
+    logger.info('Using default search for key = %s' % key)
     raise ValueError("Must give an integer scan ID like [6], a slice "
                      "into past scans like [-5], [-5:], or [-5:-9:2], "
                      "a list like [1, 7, 13], a (partial) uid "
@@ -49,6 +50,7 @@ def search(key):
 @search.register(slice)
 def _(key):
     # Interpret key as a slice into previous scans.
+    logger.info('Interpreting key = %s as a slice' % key)
     if key.start is not None and key.start > -1:
         raise ValueError("slice.start must be negative. You gave me "
                          "key=%s The offending part is key.start=%s"
@@ -74,6 +76,7 @@ def _(key):
 
 @search.register(numbers.Integral)
 def _(key):
+    logger.info('Interpreting key = %s as an integer' % key)
     if key > -1:
         # Interpret key as a scan_id.
         gen = find_run_starts(scan_id=key)
@@ -98,6 +101,7 @@ def _(key):
 
 @search.register(str)
 def _(key):
+    logger.info('Interpreting key = %s as a str' % key)
     results = None
     if len(key) >= 36:
         # Interpret key as a uid (or the few several characters of one).
@@ -125,6 +129,8 @@ def _(key):
 @search.register(tuple)
 @search.register(MutableSequence)
 def _(key):
+    logger.info('Interpreting key = {} as a set, tuple or MutableSequence'
+                ''.format(key))
     return [search(k) for k in key]
 
 

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -115,6 +115,7 @@ def _(key):
     return header
 
 
+@search.register(set)
 @search.register(tuple)
 @search.register(abc.MutableSequence)
 def _(key):

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-
+from collections import deque
 import six
 import uuid
 import logging
@@ -179,9 +179,24 @@ def test_uid_lookup():
     assert_raises(ValueError, lambda: db[uid[0]])
 
 
-def test_set_search():
+def _search_helper(query):
+    # basically assert that the search does not raise anything
+    db[query]
+
+
+def test_search_for_smoke():
     # smoketest the search with a set
-    db[{-1, -2}]
+    queries = [
+        {'-1', '-2'},
+        ('-1', '-2'),
+        '-1',
+        -1,
+        ['-1', '-2'],
+        deque(['-1', -2]),
+        slice(-1, -5, -1),
+    ]
+    for query in queries:
+        yield _search_helper, query
 
 
 def test_data_key():

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -1,6 +1,4 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-from collections import deque
+from __future__ import absolute_import, division, print_function
 import six
 import uuid
 import logging

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -177,26 +177,6 @@ def test_uid_lookup():
     assert_raises(ValueError, lambda: db[uid[0]])
 
 
-def _search_helper(query):
-    # basically assert that the search does not raise anything
-    db[query]
-
-
-def test_search_for_smoke():
-    # smoketest the search with a set
-    queries = [
-        {'-1', '-2'},
-        ('-1', '-2'),
-        '-1',
-        -1,
-        ['-1', '-2'],
-        deque(['-1', -2]),
-        slice(-1, -5, -1),
-    ]
-    for query in queries:
-        yield _search_helper, query
-
-
 def test_data_key():
     rs1_uid = insert_run_start(time=100., scan_id=1,
                                owner='nedbrainard', beamline_id='example',
@@ -219,6 +199,32 @@ def test_data_key():
     assert_equal(len(result2), 1)
     actual = result2[0]['start']['uid']
     assert_equal(actual, str(rs2.uid))
+
+
+
+def _search_helper(query):
+    # basically assert that the search does not raise anything
+    db[query]
+
+
+def test_search_for_smoke():
+    # smoketest the search with a set
+    uid1 = db[-1]['start']['uid'][:8]
+    uid2 = db[-2]['start']['uid'][:8]
+    uid3 = db[-3]['start']['uid'][:8]
+    queries = [
+        {-1, -2},
+        (-1, -2),
+        -1,
+        uid1,
+        six.text_type(uid1),
+        [uid1, [uid2, uid3]],
+        [-1, uid1, slice(-5, 0)],
+        slice(-5, 0, 2),
+        slice(-5, 0),
+    ]
+    for query in queries:
+        yield _search_helper, query
 
 
 @raises(ValueError)

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -179,6 +179,11 @@ def test_uid_lookup():
     assert_raises(ValueError, lambda: db[uid[0]])
 
 
+def test_set_search():
+    # smoketest the search with a set
+    db[{-1, -2}]
+
+
 def test_data_key():
     rs1_uid = insert_run_start(time=100., scan_id=1,
                                owner='nedbrainard', beamline_id='example',

--- a/databroker/tests/test_broker_search.py
+++ b/databroker/tests/test_broker_search.py
@@ -1,1 +1,0 @@
-__author__ = 'edill'

--- a/databroker/tests/test_broker_search.py
+++ b/databroker/tests/test_broker_search.py
@@ -1,0 +1,1 @@
+__author__ = 'edill'


### PR DESCRIPTION
This provides more flexibility at no cost.  We can, at any time, extend
the functionality of the databroker to handle new argument types to the
db[] notation by using singledispatch

Blocking Issues
----------------
- [x] Test conda-recipe on python 2.7