### PR TITLE
ENH: Implement a drop-in replacement for RunEngine Document Dispatcher.

### DIFF
--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -2,12 +2,12 @@ import logging
 
 
 logger = logging.getLogger(__name__)
-__all__ = ['DataBroker', 'get_images', 'get_events', 'get_table']
+__all__ = ['DataBroker', 'get_images', 'get_events', 'get_table', 'stream']
 
 
 # generally useful imports
 from .databroker import (DataBroker, DataBroker as db,
-                         get_events, get_table, search)
+                         get_events, get_table, search, stream)
 from .pims_readers import get_images
 from .handler_registration import register_builtin_handlers
 

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -423,3 +423,45 @@ def get_table(headers, fields=None, fill=True, convert_times=True):
     else:
         # edge case: no data
         return pd.DataFrame()
+
+
+def stream(headers, fields=None, fill=True):
+    """
+    Get all Documents from given run(s).
+
+
+    Parameters
+    ----------
+    headers : Header or iterable of Headers
+        The headers to fetch the events for
+    fields : list, optional
+        whitelist of field names of interest; if None, all are returned
+    fill : bool, optional
+        Whether externally-stored data should be filled in. Defaults to True
+
+    Yields
+    ------
+    name, doc : tuple
+        string name of the Document type and the Document itself.
+        Example: ('start', {'time': ..., ...})
+
+    Note
+    ----
+    This output can be used as a drop-in replacement for the output of the
+    bluesky Run Engine.
+    """
+    try:
+        headers.items()
+    except AttributeError:
+        pass
+    else:
+        headers = [headers]
+
+    for header in headers:
+        yield 'start', header['start']
+        for descriptor in header['descriptors']:
+            yield 'descriptor', descriptor
+        # When py2 compatibility is dropped, use yield from.
+        for event in get_events(header, fields=fields, fill=fill):
+            yield 'event', event
+        yield 'stop', header['stop']

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -245,7 +245,11 @@ def test_raise_conditions():
 
 
 def test_stream():
-    s = stream(db[-1])
+    rs = insert_run_start(time=ttime.time(), scan_id=105,
+                          owner='stepper', beamline_id='example',
+                          uid=str(uuid.uuid4()))
+    step_scan.run(run_start_uid=rs)
+    s = stream(db[rs])
     name, doc = next(s)
     assert name == 'start'
     assert 'owner' in doc

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -3,7 +3,7 @@ import six
 import uuid
 import logging
 import time as ttime
-from databroker import DataBroker as db, get_events, get_table
+from databroker import DataBroker as db, get_events, get_table, stream
 from ..examples.sample_data import (temperature_ramp, image_and_scalar,
                                     step_scan)
 from nose.tools import (assert_equal, assert_raises, assert_true,
@@ -242,3 +242,22 @@ def test_raise_conditions():
     ]
     for raiser in raising_keys:
         yield _raiser_helper, raiser
+
+
+def test_stream():
+    s = stream(db[-1])
+    name, doc = next(s)
+    assert name == 'start'
+    assert 'owner' in doc
+    name, doc = next(s)
+    assert name == 'descriptor'
+    assert 'data_keys' in doc
+    last_item  = 'event', {'data'}  # fake Event to prime loop
+    for item in s:
+        name, doc = last_item
+        assert name == 'event'
+        assert 'data' in doc  # Event
+        last_item = item
+    name, doc = last_item
+    assert name == 'stop'
+    assert 'exit_status' in doc # Stop


### PR DESCRIPTION
We documented this but never actually wrote it.

Having trouble running tests locally due to pip problems + pymongo thrashing.