### PR TITLE
ENH: KeyError to catch probably spelling mistake

### DIFF
--- a/databroker/pims_readers.py
+++ b/databroker/pims_readers.py
@@ -45,6 +45,8 @@ class Images(FramesSequence):
         """
         events = get_events(headers, [name], fill=False)
         self._datum_uids = [event.data[name] for event in events]
+        if not self._datum_uids:
+            raise KeyError("No Events contain the key %r" % name)
         self._len = len(self._datum_uids)
         example_frame = retrieve(self._datum_uids[0])
         self._dtype = example_frame.dtype

--- a/databroker/tests/test_misc.py
+++ b/databroker/tests/test_misc.py
@@ -6,7 +6,7 @@ from metadatastore.utils.testing import mds_setup, mds_teardown
 from filestore.utils.testing import fs_setup, fs_teardown
 import numpy as np
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_raises
 from numpy.testing.utils import assert_array_equal
 
 def test_watermark():
@@ -28,6 +28,8 @@ def test_pims_images():
     assert_equal(images.pixel_type, np.float64)
     assert_array_equal(images.frame_shape, images[0].shape)
     assert_equal(len(images), image_and_scalar.num1)
+    with assert_raises(KeyError):
+        get_images(header, 'nonexistent_key')
 
 
 def setup():


### PR DESCRIPTION
`get_images(header, 'nonexistent_key')` dies somewhere down in filestore/pims with an error saying something about iteration. This confused me for a couple minutes, so I guess we ought to provide a better error.

This PR raises a KeyError if the internal call to `get_events(header, ['nonexistent_key'])` comes back empty.