### PR TITLE
ENH: Add process; rename stream -> restream (with back-compat)

### DIFF
--- a/databroker/__init__.py
+++ b/databroker/__init__.py
@@ -3,12 +3,13 @@ import logging
 
 logger = logging.getLogger(__name__)
 __all__ = ['DataBroker', 'get_images', 'get_events', 'get_table', 'stream',
-           'get_fields']
+           'get_fields', 'restream', 'process']
 
 
 # generally useful imports
 from .databroker import (DataBroker, DataBroker as db,
-                         get_events, get_table, search, stream, get_fields)
+                         get_events, get_table, search, stream, get_fields,
+                         restream, process)
 from .pims_readers import get_images
 from .handler_registration import register_builtin_handlers
 

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -437,15 +437,14 @@ def get_table(headers, fields=None, fill=True, convert_times=True):
         return pd.DataFrame()
 
 
-def stream(headers, fields=None, fill=True):
+def restream(headers, fields=None, fill=True):
     """
     Get all Documents from given run(s).
-
 
     Parameters
     ----------
     headers : Header or iterable of Headers
-        The headers to fetch the events for
+        header or headers to fetch the documents for
     fields : list, optional
         whitelist of field names of interest; if None, all are returned
     fill : bool, optional
@@ -463,13 +462,17 @@ def stream(headers, fields=None, fill=True):
     ...     # do something
     ...
     >>> h = DataBroker[-1]  # most recent header
-    >>> for name, doc in stream(h):
+    >>> for name, doc in restream(h):
     ...     f(name, doc)
 
     Note
     ----
     This output can be used as a drop-in replacement for the output of the
     bluesky Run Engine.
+
+    See Also
+    --------
+    process
     """
     try:
         headers.items()
@@ -486,6 +489,46 @@ def stream(headers, fields=None, fill=True):
         for event in get_events(header, fields=fields, fill=fill):
             yield 'event', event
         yield 'stop', header['stop']
+
+
+stream = restream  # compat
+
+
+def process(headers, func, fields=None, fill=True):
+    """
+    Get all Documents from given run to a callback.
+
+    Parameters
+    ----------
+    headers : Header or iterable of Headers
+        header or headers to process documents from
+    func : callable
+        function with the signature `f(name, doc)`
+        where `name` is a string and `doc` is a dict
+    fields : list, optional
+        whitelist of field names of interest; if None, all are returned
+    fill : bool, optional
+        Whether externally-stored data should be filled in. Defaults to True
+
+    Example
+    -------
+    >>> def f(name, doc):
+    ...     # do something
+    ...
+    >>> h = DataBroker[-1]  # most recent header
+    >>> process(h, f)
+
+    Note
+    ----
+    This output can be used as a drop-in replacement for the output of the
+    bluesky Run Engine.
+
+    See Also
+    --------
+    restream
+    """
+    for name, doc in restream(headers, fields, fill):
+        func(name, doc)
 
 
 def get_fields(header):

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import, division, print_function
 import six
 import uuid
 import logging
+from itertools import count
 import time as ttime
 from databroker import (DataBroker as db, get_events, get_table, stream,
-                        get_fields)
+                        get_fields, restream, process)
 from ..examples.sample_data import (temperature_ramp, image_and_scalar,
                                     step_scan)
 from nose.tools import (assert_equal, assert_raises, assert_true,
@@ -246,11 +247,16 @@ def test_raise_conditions():
 
 
 def test_stream():
+    _stream(restream)
+    _stream(stream)  # old name
+
+
+def _stream(func):
     rs = insert_run_start(time=ttime.time(), scan_id=105,
                           owner='stepper', beamline_id='example',
                           uid=str(uuid.uuid4()))
     step_scan.run(run_start_uid=rs)
-    s = stream(db[rs])
+    s = func(db[rs])
     name, doc = next(s)
     assert name == 'start'
     assert 'owner' in doc
@@ -266,6 +272,19 @@ def test_stream():
     name, doc = last_item
     assert name == 'stop'
     assert 'exit_status' in doc # Stop
+
+
+def test_process():
+    rs = insert_run_start(time=ttime.time(), scan_id=105,
+                          owner='stepper', beamline_id='example',
+                          uid=str(uuid.uuid4()))
+    step_scan.run(run_start_uid=rs)
+    c = count()
+    def f(name, doc):
+        next(c)
+
+    process(db[rs], f)
+    assert next(c) == len(list(restream(db[rs])))
 
 
 def test_get_fields():

--- a/doc/source/fetching.rst
+++ b/doc/source/fetching.rst
@@ -7,7 +7,8 @@ Fetching Data
    ~databroker.databroker.get_table
    ~databroker.pims_readers.get_images
    ~databroker.databroker.get_events
-   ~databroker.databroker.stream
+   ~databroker.databroker.restream
+   ~databroker.databroker.process
    ~databroker.databroker.get_fields
 
 Click any of the function names above for more detail.


### PR DESCRIPTION
A primary use case for the recently-introduced `restream` (formerly called `stream`) is a list comprehension:

```python
docs = restream(header)  # a generator
[some_callback(name, doc) for name, doc in docs]
```

This PR introduces a convenience function to make that easy.

```python
process(header, some_callback)
```

Perhaps we should accept a list of callbacks or, as in bluesky, the dict `{'all': [...], 'start': [...], ...}` routing documents by type. But I think it's best to keep it simple here. If users need to use multiple callbacks, they can always roll their own dispatching function or use `CallbackBase`.