### PR TITLE
ENH: Search for fields in event, descriptor, start, stop.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - conda config --set always_yes true
   - conda update conda
   # pin to numpy < 1.10 because pandas 0.16 and numpy 1.10 do not play nice
-  - conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION six "numpy<1.10" pandas h5py coverage jsonschema jinja2
+  - conda create -n testenv pip nose python=$TRAVIS_PYTHON_VERSION six "numpy<1.10" pandas h5py coverage jsonschema jinja2 cytoolz
   - source activate testenv
   # deps needed for metadatastore/filestore
   - conda install -n testenv pyyaml

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,6 +16,7 @@ requirements:
   run:
     - python
     - pandas
+    - cytoolz
     - pims
     - metadatastore >=v0.2.0
     - filestore >=v0.2.0

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -450,7 +450,7 @@ def get_table(headers, fields=None, fill=True, convert_times=True):
                 logger.debug('Discarding field %s', field)
                 del df[field]
             for field in df.columns:
-                if is_external.get(field, False) and fill:
+                if is_external.get(field) and fill:
                     logger.debug('filling data for %s', field)
                     # TODO someday we will have bulk retrieve in FS
                     datum_uids = df[field]

--- a/databroker/examples/sample_data/step_scan.py
+++ b/databroker/examples/sample_data/step_scan.py
@@ -22,9 +22,14 @@ def run(run_start=None, sleep=0):
     # Create Event Descriptors
     data_keys = {'Tsam': dict(source='PV:ES:Tsam', dtype='number'),
                  'point_det': dict(source='PV:ES:point_det', dtype='number')}
+    conf = {'point_det': {'data_keys': {'exposure_time':
+                                        {'source': 'PS:ES:point_det_exp'}},
+                          'data': {'exposure_time': 5},
+                          'timestamps': {'exposure_time': 0.}}}
     ev_desc = insert_descriptor(run_start=run_start,
-                                      data_keys=data_keys, time=0.,
-                                      uid=str(uuid.uuid4()))
+                                data_keys=data_keys, time=0.,
+                                uid=str(uuid.uuid4()),
+                                configuration=conf)
 
     # Create Events.
     events = []

--- a/databroker/pims_readers.py
+++ b/databroker/pims_readers.py
@@ -44,7 +44,8 @@ class Images(FramesSequence):
                 # do something
         """
         events = get_events(headers, [name], fill=False)
-        self._datum_uids = [event.data[name] for event in events]
+        self._datum_uids = [event.data[name] for event in events
+                            if name in event.data]
         self._len = len(self._datum_uids)
         example_frame = retrieve(self._datum_uids[0])
         self._dtype = example_frame.dtype

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -71,7 +71,7 @@ def test_basic_usage():
     get_table(header_null)
 
     # get events for multiple headers
-    list(get_events([header_1, header_ned]))
+    list(get_events(db[-2:]))
 
     # test time shift issue GH9
     table = get_table(db[105])

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -284,3 +284,30 @@ def test_get_fields():
     h = db[rs]
     actual = get_fields(h)
     assert actual == set(['Tsam', 'point_det'])
+
+
+def test_configuration():
+    rs = insert_run_start(time=ttime.time(), scan_id=105,
+                          owner='stepper', beamline_id='example',
+                          uid=str(uuid.uuid4()), cat='meow')
+    step_scan.run(run_start_uid=rs)
+    h = db[rs]
+    # check that config is not included by default
+    ev = next(get_events(h))
+    assert set(ev['data'].keys()) == set(['Tsam', 'point_det'])
+    # find config in descriptor['configuration']
+    ev = next(get_events(h, fields=['Tsam', 'exposure_time']))
+    assert 'exposure_time' in ev['data']
+    assert ev['data']['exposure_time'] == 5
+    assert 'exposure_time' in ev['timestamps']
+    assert ev['timestamps']['exposure_time'] == 0.
+    # find config in start doc
+    ev = next(get_events(h, fields=['Tsam', 'cat']))
+    assert 'cat' in ev['data']
+    assert ev['data']['cat'] == 'meow'
+    assert 'cat' in ev['timestamps']
+    # find config in stop doc
+    ev = next(get_events(h, fields=['Tsam', 'exit_status']))
+    assert 'exit_status' in ev['data']
+    assert ev['data']['exit_status'] == 'success'
+    assert 'exit_status' in ev['timestamps']

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -64,7 +64,6 @@ def test_basic_usage():
     db.fetch_events(header_ned)
     db.fetch_events(header_null)
     list(get_events(header_1))
-    list(get_events(header_ned))
     list(get_events(header_null))
     get_table(header_1)
     get_table(header_ned)


### PR DESCRIPTION
- Any fields not found in an event will be looked for in
  its descriptor's configuration, then in start, then in stop.
- This passes the existing tests, which use documents that have
  no 'configuration' field at all. More tests coming.
- A dependency on cytoolz or toolz (same API) is introduced.