### PR TITLE
ENH: Allow hanlder override by data key.

### DIFF
--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -483,7 +483,8 @@ def get_table(headers, fields=None, fill=True, convert_times=True,
                     # TODO someday we will have bulk retrieve in FS
                     datum_uids = df[field]
                     if field not in handler_overrides:
-                        values = [fs.retrieve(value) for value in datum_uids]
+                        values = [fs.retrieve(value, handler_registry)
+                                  for value in datum_uids]
                     else:
                         handler = handler_overrides[field]
                         mock_registry = defaultdict(lambda: handler)

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -474,9 +474,14 @@ def get_table(headers, fields=None, fill=True, convert_times=True,
                     pd.Series(times, index=seq_nums),
                     unit='s', utc=True).dt.tz_localize(TZ)
             df['time'] = times
-            for field in discard_fields:
-                logger.debug('Discarding field %s', field)
-                del df[field]
+            for field, values in six.iteritems(data):
+                if field in discard_fields:
+                    logger.debug('Discarding field %s', field)
+                    continue
+                df[field] = values
+            if list(df.columns) == ['time']:
+                # no content
+                continue
             for field in df.columns:
                 if is_external.get(field) and fill:
                     logger.debug('filling data for %s', field)

--- a/databroker/pims_readers.py
+++ b/databroker/pims_readers.py
@@ -1,11 +1,12 @@
 """This module contains "PIMS readers" (see github.com/soft-matter/pims) that
 take in headers and detector aliases and return a sliceable generator of arrays."""
 
+from collections import defaultdict
 from pims import FramesSequence, Frame
 from . import get_events
 from filestore.api import retrieve
 
-def get_images(headers, name):
+def get_images(headers, name, handler_registry=None, handler_override=None):
     """
     Load images from a detector for given Header(s).
 
@@ -14,6 +15,11 @@ def get_images(headers, name):
     headers : Header or list of Headers
     name : string
         field name (data key) of a detector
+    handler_registry : dict, optional
+        mapping spec names (strings) to handlers (callable classes)
+    handler_override : callable class, optional
+        overrides registered handlers
+        
 
     Example
     -------
@@ -22,11 +28,12 @@ def get_images(headers, name):
     >>> for image in images:
             # do something
     """
-    return Images(headers, name)
+    return Images(headers, name, handler_registry, handler_override)
 
 
 class Images(FramesSequence):
-    def __init__(self, headers, name):
+    def __init__(self, headers, name, handler_registry=None,
+                 handler_override=None):
         """
         Load images from a detector for given Header(s).
 
@@ -35,6 +42,10 @@ class Images(FramesSequence):
         headers : Header or list of Headers
         name : str
             field name (data key) of a detector
+        handler_registry : dict, optional
+            mapping spec names (strings) to handlers (callable classes)
+        handler_override : callable class, optional
+            overrides registered handlers
 
         Example
         -------
@@ -47,7 +58,13 @@ class Images(FramesSequence):
         self._datum_uids = [event.data[name] for event in events
                             if name in event.data]
         self._len = len(self._datum_uids)
-        example_frame = retrieve(self._datum_uids[0])
+        first_uid = self._datum_uids[0]
+        if handler_override is None:
+            self.handler_registry = handler_registry
+        else:
+            # mock a handler registry
+            self.handler_registry = defaultdict(lambda: handler_override)
+        example_frame = retrieve(first_uid, self.handler_registry)
         self._dtype = example_frame.dtype
         self._shape = example_frame.shape
 
@@ -63,5 +80,5 @@ class Images(FramesSequence):
         return self._len
 
     def get_frame(self, i):
-        img = retrieve(self._datum_uids[i])
+        img = retrieve(self._datum_uids[i], self.handler_registry)
         return Frame(img, frame_no=i)

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -5,7 +5,7 @@ import logging
 from itertools import count
 import time as ttime
 from databroker import (DataBroker as db, get_events, get_table, stream,
-                        get_fields, restream, process)
+                        get_fields, restream, process, get_images)
 from ..examples.sample_data import (temperature_ramp, image_and_scalar,
                                     step_scan)
 from nose.tools import (assert_equal, assert_raises, assert_true,
@@ -19,12 +19,22 @@ from filestore.utils.testing import fs_setup, fs_teardown
 logger = logging.getLogger(__name__)
 
 
+class DummyHandler(object):
+    def __init__(*args, **kwargs):
+        pass
+
+    def __call__(*args, **kwrags):
+        return 'dummy'
+
+
 blc = None
+image_example_uid = None
 
 
 def setup():
     mds_setup()
     fs_setup()
+    global image_example_uid
 
     owners = ['docbrown', 'nedbrainard']
     num_entries = 5
@@ -42,6 +52,7 @@ def setup():
             temperature_ramp.run(run_start_uid=rs, make_run_stop=(i != 0))
             if i == 0:
                 # only need to do images once, it takes a while...
+                image_example_uid = rs
                 image_and_scalar.run(run_start_uid=rs, make_run_stop=True)
 
 
@@ -329,3 +340,21 @@ def test_configuration():
     assert 'exit_status' in ev['data']
     assert ev['data']['exit_status'] == 'success'
     assert 'exit_status' in ev['timestamps']
+
+
+def test_handler_options():
+    h = db[image_example_uid]
+    list(get_events(h))
+    list(get_table(h))
+    res = list(get_events(h, fields=['img'],
+                          handler_registry={'npy': DummyHandler}))
+    res = [ev for ev in res if 'img' in ev['data']]
+    res[0]['data']['img'] == 'dummy'
+    res = list(get_events(h, fields=['img'],
+                          handler_overrides={'image': DummyHandler}))
+    res = [ev for ev in res if 'img' in ev['data']]
+    res[0]['data']['img'] == 'dummy'
+    res = get_table(h, ['img'], handler_registry={'npy': DummyHandler})
+    assert res['img'].iloc[0] == 'dummy'
+    res = get_table(h, ['img'], handler_overrides={'img': DummyHandler})
+    assert res['img'].iloc[0] == 'dummy'

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -346,6 +346,7 @@ def test_handler_options():
     h = db[image_example_uid]
     list(get_events(h))
     list(get_table(h))
+    list(get_images(h, 'img'))
     res = list(get_events(h, fields=['img'],
                           handler_registry={'npy': DummyHandler}))
     res = [ev for ev in res if 'img' in ev['data']]
@@ -358,3 +359,7 @@ def test_handler_options():
     assert res['img'].iloc[0] == 'dummy'
     res = get_table(h, ['img'], handler_overrides={'img': DummyHandler})
     assert res['img'].iloc[0] == 'dummy'
+    res = get_images(h, 'img', handler_registry={'npy': DummyHandler})
+    assert res[0] == 'dummy'
+    res = get_images(h, 'img', handler_override=DummyHandler)
+    assert res[0] == 'dummy'


### PR DESCRIPTION
- All get* functions also accept an optional `handler_overrides` argument
  that maps data_keys to handlers, overriding the lookup based on spec name
- The override only affects a single call.
- get_table and get_images now accept optional `handler_registry` argument
  (get_events already supported this)

Use Case:
- Debugging by say using a handler that returns raw resource/datum dicts
- Swapping lazy/non-lazy handlers as needed
- Suppose we collect data and then realize we want information that is not
  in the Events but *is* in the files (e.g., timestamps in HDF5 image files).
  This gives us a recourse: registing a custom handler that uses the same
  resource and datum documents but returns totally different data (the
  timestamps instead of the images). Obviously it's better to capture everything
  in advance, but this is liable to come up a lot.

Examples:
get_events(hdr, handler_overrides={'image': SpecialHandler})
get_table(hdr, handler_overrides{'light': Special1, 'dark': Special2})
get_images(hdr, handler_override=SpecialHandler)