### PR TITLE
API: Skip empty events.

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -173,6 +173,10 @@ def get_events(mds, fs, headers, fields=None, fill=True, handler_registry=None,
                         event_data[field] = stop[field]
                         event_timestamps[field] = stop['time']
                     # (else omit it from the events of this descriptor)
+                if not event_data:
+                    # Skip events that are now empty because they had no
+                    # applicable fields.
+                    continue
                 if fill:
                     fill_event(fs, event, handler_registry, handler_overrides)
                 yield event


### PR DESCRIPTION
At beamlines, I find myself using this pattern a lot:

```python3
events = [ev for ev in get_events(hdr, ['x']) if 'x' in ev.data]  # filter out events that don't have 'x'
```

I think `get_events` should be filtering out events that are completely empty.

I've been sitting on this awhile, because this is not a decision we should thrash on, but I've become pretty convinced that the upside outweighs in the downside in the use cases I see. Thoughts?