### PR TITLE
API: change arg name from name -> stream_name

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -318,8 +318,8 @@ class Broker(object):
         for event in res:
             yield event
 
-
-    def get_table(self, headers, fields=None, name='primary', fill=False,
+    def get_table(self, headers, fields=None, stream_name='primary',
+                  fill=False,
                   convert_times=True, timezone=None, handler_registry=None,
                   handler_overrides=None):
         """
@@ -337,7 +337,8 @@ class Broker(object):
             'primary', but if no event stream with that name is found, the
             default reverts to `None` (for backward-compatibility).
         fill : bool, optional
-            Whether externally-stored data should be filled in. Defaults to True
+            Whether externally-stored data should be filled in.
+            Defaults to True
         convert_times : bool, optional
             Whether to convert times from float (seconds since 1970) to
             numpy datetime64, using pandas. True by default.
@@ -356,14 +357,14 @@ class Broker(object):
         if timezone is None:
             timezone = self.mds.config['timezone']
         res = _get_table(mds=self.mds, fs=self.fs, headers=headers,
-                         fields=fields, name=name, fill=fill,
+                         fields=fields, stream_name=stream_name, fill=fill,
                          convert_times=convert_times,
                          timezone=timezone, handler_registry=handler_registry,
                          handler_overrides=handler_overrides)
         return res
 
     def get_images(self, headers, name, handler_registry=None,
-                  handler_override=None):
+                   handler_override=None):
         """
         Load images from a detector for given Header(s).
 
@@ -388,7 +389,6 @@ class Broker(object):
         """
         return Images(self.mds, self.fs, headers, name, handler_registry,
                       handler_override)
-
 
     def restream(self, headers, fields=None, fill=False):
         """
@@ -483,7 +483,7 @@ class ArchiverPlugin(object):
             e.g., 'http://host:port/'
         timezone : string
             e.g., 'US/Eastern'
-        
+
         Example
         -------
         >>> p = ArchiverPlugin('http://xf16idc-ca.cs.nsls2.local:17668/',

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -204,7 +204,7 @@ def get_events(mds, fs, headers, fields=None, name=None, fill=False,
                 yield ev
 
 
-def get_table(mds, fs, headers, fields=None, name='primary', fill=False,
+def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
               convert_times=True, timezone=None, handler_registry=None,
               handler_overrides=None):
     """
@@ -271,10 +271,11 @@ def get_table(mds, fs, headers, fields=None, name='primary', fill=False,
 
         # shim for back-compat with old data that has no 'primary' descriptor
         if not any(d for d in descriptors if d.get('name') == 'primary'):
-            name = None
+            stream_name = None
 
         for descriptor in descriptors:
-            if name is not None and name != descriptor.get('name'):
+            if ((stream_name is not None) and
+                    (stream_name != descriptor.get('name'))):
                 continue
             is_external = _external_keys(descriptor)
             objs_config = descriptor.get('configuration', {}).values()
@@ -499,7 +500,7 @@ def get_images(fs, headers, name, handler_registry=None,
         mapping spec names (strings) to handlers (callable classes)
     handler_override : callable class, optional
         overrides registered handlers
-        
+
 
     Example
     -------

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -1,0 +1,11 @@
+.. _api_changes:
+
+API changes
+***********
+
+Non-backward compatible API changes
+
+v0.4.2
+------
+
+ - Change ``name`` -> ``stream_name`` in the signature of `get_table`

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -76,3 +76,4 @@ See :doc:`searching` and :doc:`fetching` for details.
    searching
    fetching
    whats_new
+   api_changes


### PR DESCRIPTION
Change the name of the 5th positional arg in `get_table` from `name` ->
'stream_name`.  The new argname is clearer and aligns with the naming
convention used in LiveTable.