### PR TITLE
Fix timezones

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -394,10 +394,10 @@ class Broker(object):
         ValueError if any key in `fields` is not in at least one descriptor pre header.
         """
         res = _get_events(mds=self.mds, fs=self.fs, headers=headers,
-                         fields=fields, stream_name=stream_name, fill=fill,
-                         handler_registry=handler_registry,
-                         handler_overrides=handler_overrides,
-                         plugins=self.plugins, **kwargs)
+                          fields=fields, stream_name=stream_name, fill=fill,
+                          handler_registry=handler_registry,
+                          handler_overrides=handler_overrides,
+                          plugins=self.plugins, **kwargs)
         for event in res:
             yield event
 

--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -404,7 +404,7 @@ class Broker(object):
     def get_table(self, headers, fields=None, stream_name='primary',
                   fill=False,
                   convert_times=True, timezone=None, handler_registry=None,
-                  handler_overrides=None):
+                  handler_overrides=None, localize_times=True):
         """
         Make a table (pandas.DataFrame) from given run(s).
 
@@ -432,6 +432,21 @@ class Broker(object):
             mapping filestore specs (strings) to handlers (callable classes)
         handler_overrides : dict, optional
             mapping data keys (strings) to handlers (callable classes)
+        localize_times : bool, optional
+            If the times should be localized to the 'local' time zone.  If
+            True (the default) the time stamps are converted to the localtime
+            zone (as configure in mds).
+
+            This is problematic for several reasons:
+
+              - apparent gaps or duplicate times around DST transitions
+              - incompatibility with every other time stamp (which is in UTC)
+
+            however, this makes the dataframe repr look nicer
+
+            This implies convert_times.
+
+            Defaults to True to preserve back-compatibility.
 
         Returns
         -------
@@ -443,7 +458,8 @@ class Broker(object):
                          fields=fields, stream_name=stream_name, fill=fill,
                          convert_times=convert_times,
                          timezone=timezone, handler_registry=handler_registry,
-                         handler_overrides=handler_overrides)
+                         handler_overrides=handler_overrides,
+                         localize_times=localize_times)
         return res
 
     def get_images(self, headers, name, handler_registry=None,

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -207,7 +207,7 @@ def get_events(mds, fs, headers, fields=None, stream_name=None, fill=False,
 
 def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
               convert_times=True, timezone=None, handler_registry=None,
-              handler_overrides=None):
+              handler_overrides=None, localize_times=True):
     """
     Make a table (pandas.DataFrame) from given run(s).
 
@@ -228,14 +228,29 @@ def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
         Whether externally-stored data should be filled in. Defaults to False.
     convert_times : bool, optional
         Whether to convert times from float (seconds since 1970) to
-        numpy datetime64, using pandas. True by default.
+        numpy datetime64, using pandas. True by default, returns naive
+        datetime64 objects in UTC
     timezone : str, optional
         e.g., 'US/Eastern'
     handler_registry : dict, optional
         mapping filestore specs (strings) to handlers (callable classes)
     handler_overrides : dict, optional
         mapping data keys (strings) to handlers (callable classes)
+    localize_times : bool, optional
+        If the times should be localized to the 'local' time zone.  If
+        True (the default) the time stamps are converted to the localtime
+        zone (as configure in mds).
 
+        This is problematic for several reasons:
+
+          - apparent gaps or duplicate times around DST transitions
+          - incompatibility with every other time stamp (which is in UTC)
+
+        however, this makes the dataframe repr look nicer
+
+        This implies convert_times.
+
+        Defaults to True to preserve back-compatibility.
     Returns
     -------
     table : pandas.DataFrame
@@ -290,10 +305,20 @@ def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
             payload = mds.get_events_table(descriptor)
             descriptor, data, seq_nums, times, uids, timestamps = payload
             df = pd.DataFrame(index=seq_nums)
-            if convert_times:
-                times = pd.to_datetime(
-                    pd.Series(times, index=seq_nums),
-                    unit='s', utc=True).dt.tz_localize(timezone)
+            # if converting to datetime64 (in utc or 'local' tz)
+            if convert_times or localize_times:
+                times = pd.to_datetime(times, unit='s')
+            # make sure this is a series
+            times = pd.Series(times, index=seq_nums)
+
+            # if localizing to 'local' time
+            if localize_times:
+                times = (times
+                         .dt.tz_localize('UTC')     # first make tz aware
+                         .dt.tz_convert(timezone)   # convert to 'local'
+                         .dt.tz_localize(None)      # make naive again
+                         )
+
             df['time'] = times
             for field, values in six.iteritems(data):
                 if field in discard_fields:


### PR DESCRIPTION
```python
import databroker
import bluesky
import bluesky.plans as bp
import datetime
from bluesky.examples import det

# or a port
# import metadatastore.mds
# mds = metadatastore.mds.MDS({'host': 'localhost', 'database': 'time_test', 'port': 27017,
#                              'timezone': 'US/Eastern'}, auth=False)

import portable_mds.sqlite.mds as pmsm

mds = pmsm.MDS({'directory': '/tmp/pmds', 'timezone': 'US/Eastern'})
db = databroker.Broker(mds, None)



class TimeFaker:
    def __init__(self, mds, start_time, step):
        self.start_time = start_time.timestamp()
        self.step = step
        self.counter = 0
        self.mds = mds
        self.last_uid = None
        
    def insert(self, name, doc):
        if name == 'start':
            self.counter = 0
            self.last_uid = doc['uid']
            
        if 'time' in doc:
            doc['time'] = self.start_time + self.counter * self.step
        self.counter += 1
        self.mds.insert(name, doc)
    

start_time = datetime.datetime(2016, 3, 12, 23, 5)
# start_time = datetime.datetime(2016, 11, 5, 23, 5)

tf = TimeFaker(db.mds, start_time, 5*60)

RE = bluesky.RunEngine()
RE.subscribe('all', tf.insert)

RE(bp.count([det], 50))

print(db.get_table(db[tf.last_uid]))
```

which gives the following tables
<details>
```
In [20]:                   time  det
1  2016-11-05 23:15:00  1.0
2  2016-11-05 23:20:00  1.0
3  2016-11-05 23:25:00  1.0
4  2016-11-05 23:30:00  1.0
5  2016-11-05 23:35:00  1.0
6  2016-11-05 23:40:00  1.0
7  2016-11-05 23:45:00  1.0
8  2016-11-05 23:50:00  1.0
9  2016-11-05 23:55:00  1.0
10 2016-11-06 00:00:00  1.0
11 2016-11-06 00:05:00  1.0
12 2016-11-06 00:10:00  1.0
13 2016-11-06 00:15:00  1.0
14 2016-11-06 00:20:00  1.0
15 2016-11-06 00:25:00  1.0
16 2016-11-06 00:30:00  1.0
17 2016-11-06 00:35:00  1.0
18 2016-11-06 00:40:00  1.0
19 2016-11-06 00:45:00  1.0
20 2016-11-06 00:50:00  1.0
21 2016-11-06 00:55:00  1.0
22 2016-11-06 01:00:00  1.0
23 2016-11-06 01:05:00  1.0
24 2016-11-06 01:10:00  1.0
25 2016-11-06 01:15:00  1.0
26 2016-11-06 01:20:00  1.0
27 2016-11-06 01:25:00  1.0
28 2016-11-06 01:30:00  1.0
29 2016-11-06 01:35:00  1.0
30 2016-11-06 01:40:00  1.0
31 2016-11-06 01:45:00  1.0
32 2016-11-06 01:50:00  1.0
33 2016-11-06 01:55:00  1.0
34 2016-11-06 01:00:00  1.0
35 2016-11-06 01:05:00  1.0
36 2016-11-06 01:10:00  1.0
37 2016-11-06 01:15:00  1.0
38 2016-11-06 01:20:00  1.0
39 2016-11-06 01:25:00  1.0
40 2016-11-06 01:30:00  1.0
41 2016-11-06 01:35:00  1.0
42 2016-11-06 01:40:00  1.0
43 2016-11-06 01:45:00  1.0
44 2016-11-06 01:50:00  1.0
45 2016-11-06 01:55:00  1.0
46 2016-11-06 02:00:00  1.0
47 2016-11-06 02:05:00  1.0
48 2016-11-06 02:10:00  1.0
49 2016-11-06 02:15:00  1.0
50 2016-11-06 02:20:00  1.0

In [21]:                   time  det
1  2016-03-12 23:15:00  1.0
2  2016-03-12 23:20:00  1.0
3  2016-03-12 23:25:00  1.0
4  2016-03-12 23:30:00  1.0
5  2016-03-12 23:35:00  1.0
6  2016-03-12 23:40:00  1.0
7  2016-03-12 23:45:00  1.0
8  2016-03-12 23:50:00  1.0
9  2016-03-12 23:55:00  1.0
10 2016-03-13 00:00:00  1.0
11 2016-03-13 00:05:00  1.0
12 2016-03-13 00:10:00  1.0
13 2016-03-13 00:15:00  1.0
14 2016-03-13 00:20:00  1.0
15 2016-03-13 00:25:00  1.0
16 2016-03-13 00:30:00  1.0
17 2016-03-13 00:35:00  1.0
18 2016-03-13 00:40:00  1.0
19 2016-03-13 00:45:00  1.0
20 2016-03-13 00:50:00  1.0
21 2016-03-13 00:55:00  1.0
22 2016-03-13 01:00:00  1.0
23 2016-03-13 01:05:00  1.0
24 2016-03-13 01:10:00  1.0
25 2016-03-13 01:15:00  1.0
26 2016-03-13 01:20:00  1.0
27 2016-03-13 01:25:00  1.0
28 2016-03-13 01:30:00  1.0
29 2016-03-13 01:35:00  1.0
30 2016-03-13 01:40:00  1.0
31 2016-03-13 01:45:00  1.0
32 2016-03-13 01:50:00  1.0
33 2016-03-13 01:55:00  1.0
34 2016-03-13 03:00:00  1.0
35 2016-03-13 03:05:00  1.0
36 2016-03-13 03:10:00  1.0
37 2016-03-13 03:15:00  1.0
38 2016-03-13 03:20:00  1.0
39 2016-03-13 03:25:00  1.0
40 2016-03-13 03:30:00  1.0
41 2016-03-13 03:35:00  1.0
42 2016-03-13 03:40:00  1.0
43 2016-03-13 03:45:00  1.0
44 2016-03-13 03:50:00  1.0
45 2016-03-13 03:55:00  1.0
46 2016-03-13 04:00:00  1.0
47 2016-03-13 04:05:00  1.0
48 2016-03-13 04:10:00  1.0
49 2016-03-13 04:15:00  1.0
50 2016-03-13 04:20:00  1.0

In [22]: 
```
</details>

This should probably pick up a test or two.  Fortunately the failure mode here is only on spring forward so this will not break this weekend.

The data was always being saved correctly as UTC, this is purely a data extraction issue (so no risk of future data loss and no existing data is corrupted).

The underlying bug is mirrored to https://github.com/NSLS-II/datamuxer/issues/3 and needs a PR into muxer to fix.