### PR TITLE
MNT: Add flexibility that would allow a separate EventStore.

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -246,7 +246,7 @@ def _(key, mds):
 
 
 class Broker(object):
-    def __init__(self, mds, fs, plugins=None, filters=None):
+    def __init__(self, mds, fs, plugins=None, filters=None, es=None):
         """
         Unified interface to data sources
 
@@ -260,9 +260,12 @@ class Broker(object):
         filters : list
             list of mongo queries to be combined with query using '$and',
             acting as a filter to restrict the results
+        es : EventStoreRO, optional
+            If not provides, mds is expected to provide event storage.
         """
         self.mds = mds
         self.fs = fs
+        self.es = es
         if plugins is None:
             plugins = {}
         self.plugins = plugins
@@ -270,6 +273,17 @@ class Broker(object):
             filters = []
         self.filters = filters
         self.aliases = {}
+
+    @property
+    def es(self):
+        return self._es
+
+    @es.setter
+    def es(self, es):
+        if es is None:
+            self._es = self.mds
+        else:
+            self._es = es
 
     ALL = ALL  # sentinel used as default value for `stream_name`
 
@@ -514,7 +528,7 @@ class Broker(object):
         ------
         ValueError if any key in `fields` is not in at least one descriptor pre header.
         """
-        res = _get_events(mds=self.mds, fs=self.fs, headers=headers,
+        res = _get_events(mds=self.mds, fs=self.fs, es=self.es, headers=headers,
                           fields=fields, stream_name=stream_name, fill=fill,
                           handler_registry=handler_registry,
                           handler_overrides=handler_overrides,
@@ -576,7 +590,7 @@ class Broker(object):
         """
         if timezone is None:
             timezone = self.mds.config['timezone']
-        res = _get_table(mds=self.mds, fs=self.fs, headers=headers,
+        res = _get_table(mds=self.mds, fs=self.fs, es=self.es, headers=headers,
                          fields=fields, stream_name=stream_name, fill=fill,
                          convert_times=convert_times,
                          timezone=timezone, handler_registry=handler_registry,
@@ -608,8 +622,9 @@ class Broker(object):
         >>> for image in images:
                 # do something
         """
-        return Images(self.mds, self.fs, headers, name, handler_registry,
-                      handler_override)
+        return Images(mds=self.mds, fs=self.fs, es=self.es, headers=headers,
+                      name=name, handler_registry=handler_registry,
+                      handler_override=handler_override)
 
     def get_resource_uids(self, header):
         '''Given a Header, give back a list of resource uids
@@ -677,7 +692,8 @@ class Broker(object):
         --------
         process
         """
-        res = _restream(self.mds, self.fs, headers, fields=fields, fill=fill)
+        res = _restream(mds=self.mds, fs=self.fs, es=self.es, headers=headers,
+                        fields=fields, fill=fill)
         for name_doc_pair in res:
             yield name_doc_pair
 
@@ -717,8 +733,8 @@ class Broker(object):
         --------
         restream
         """
-        _process(mds=self.mds, fs=self.fs, headers=headers, func=func,
-                 fields=fields, fill=fill)
+        _process(mds=self.mds, fs=self.fs, es=self.es, headers=headers,
+                 func=func, fields=fields, fill=fill)
 
     get_fields = staticmethod(get_fields)  # for convenience
 

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -100,7 +100,7 @@ class Header(doc.Document):
         return cls('header', d)
 
 
-def get_events(mds, fs, headers, fields=None, stream_name=ALL, fill=False,
+def get_events(mds, fs, es, headers, fields=None, stream_name=ALL, fill=False,
                handler_registry=None, handler_overrides=None, plugins=None,
                **kwargs):
     """
@@ -110,6 +110,7 @@ def get_events(mds, fs, headers, fields=None, stream_name=ALL, fill=False,
     ----------
     mds : MDSRO
     fs : FileStoreRO
+    es : EventStoreRO
     headers : Header or iterable of Headers
         The headers to fetch the events for
     fields : list, optional
@@ -204,7 +205,7 @@ def get_events(mds, fs, headers, fields=None, stream_name=ALL, fill=False,
                     all_extra_data[field] = stop[field]
                     all_extra_ts[field] = stop['time']
 
-            for event in mds.get_events_generator(descriptor):
+            for event in es.get_events_generator(descriptor):
                 event_data = event.data  # cache for perf
                 event_timestamps = event.timestamps
                 event_data.update(all_extra_data)
@@ -225,9 +226,10 @@ def get_events(mds, fs, headers, fields=None, stream_name=ALL, fill=False,
                 yield ev
 
 
-def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
-              convert_times=True, timezone=None, handler_registry=None,
-              handler_overrides=None, localize_times=True):
+def get_table(mds, fs, es, headers, fields=None, stream_name='primary',
+              fill=False, convert_times=True, timezone=None,
+              handler_registry=None, handler_overrides=None,
+              localize_times=True):
     """
     Make a table (pandas.DataFrame) from given run(s).
 
@@ -235,6 +237,7 @@ def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
     ----------
     mds : MDSRO
     fs : FileStoreRO
+    es : EventStoreRO
     headers : Header or iterable of Headers
         The headers to fetch the events for
     fields : list, optional
@@ -272,6 +275,7 @@ def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
         This implies convert_times.
 
         Defaults to True to preserve back-compatibility.
+
     Returns
     -------
     table : pandas.DataFrame
@@ -323,7 +327,7 @@ def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
                 event_fields = set(descriptor['data_keys'])
                 discard_fields = event_fields - fields
                 extra_fields = fields - event_fields
-            payload = mds.get_events_table(descriptor)
+            payload = es.get_events_table(descriptor)
             descriptor, data, seq_nums, times, uids, timestamps = payload
             df = pd.DataFrame(index=seq_nums)
             # if converting to datetime64 (in utc or 'local' tz)
@@ -383,7 +387,7 @@ def get_table(mds, fs, headers, fields=None, stream_name='primary', fill=False,
         return pd.DataFrame()
 
 
-def restream(mds, fs, headers, fields=None, fill=False):
+def restream(mds, fs, es, headers, fields=None, fill=False):
     """
     Get all Documents from given run(s).
 
@@ -391,6 +395,7 @@ def restream(mds, fs, headers, fields=None, fill=False):
     ----------
     mds : MDSRO
     fs : FileStoreRO
+    es : EventStoreRO
     headers : Header or iterable of Headers
         header or headers to fetch the documents for
     fields : list, optional
@@ -434,7 +439,7 @@ def restream(mds, fs, headers, fields=None, fill=False):
         for descriptor in header['descriptors']:
             yield 'descriptor', descriptor
         # When py2 compatibility is dropped, use yield from.
-        for event in get_events(mds, fs, header, fields=fields, fill=fill):
+        for event in get_events(mds, fs, es, header, fields=fields, fill=fill):
             yield 'event', event
         yield 'stop', header['stop']
 
@@ -442,7 +447,7 @@ def restream(mds, fs, headers, fields=None, fill=False):
 stream = restream  # compat
 
 
-def process(mds, fs, headers, func, fields=None, fill=False):
+def process(mds, fs, es, headers, func, fields=None, fill=False):
     """
     Get all Documents from given run to a callback.
 
@@ -450,6 +455,7 @@ def process(mds, fs, headers, func, fields=None, fill=False):
     ----------
     mds : MDSRO
     fs : FileStoreRO
+    es : EventStoreRO
     headers : Header or iterable of Headers
         header or headers to process documents from
     func : callable
@@ -477,7 +483,7 @@ def process(mds, fs, headers, func, fields=None, fill=False):
     --------
     restream
     """
-    for name, doc in restream(mds, fs, headers, fields, fill):
+    for name, doc in restream(mds, fs, es, headers, fields, fill):
         func(name, doc)
 
 
@@ -583,7 +589,7 @@ def get_images(fs, headers, name, handler_registry=None,
 
 
 class Images(FramesSequence):
-    def __init__(self, mds, fs, headers, name, handler_registry=None,
+    def __init__(self, mds, fs, es, headers, name, handler_registry=None,
                  handler_override=None):
         """
         Load images from a detector for given Header(s).
@@ -592,6 +598,7 @@ class Images(FramesSequence):
         ----------
         fs : FileStoreRO
         headers : Header or list of Headers
+        es : EventStoreRO
         name : str
             field name (data key) of a detector
         handler_registry : dict, optional
@@ -607,7 +614,7 @@ class Images(FramesSequence):
                 # do something
         """
         self.fs = fs
-        events = get_events(mds, fs, headers, [name], fill=False)
+        events = get_events(mds, fs, es, headers, [name], fill=False)
         self._datum_uids = [event.data[name] for event in events
                             if name in event.data]
         self._len = len(self._datum_uids)

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -5,6 +5,13 @@ API changes
 
 Non-backward compatible API changes
 
+dev
+---
+
+* The core functions that touch events have a new required argument, ``es``.
+  This does not affect the API of the ``Broker`` object, only the functions in
+  the ``core`` module.
+
 v0.4.2
 ------
 


### PR DESCRIPTION
As we experiment with different MDS backends for portability and performance, it might make sense to be able to choose the backend for headers and the backend for events separately. For example, it seems likely that all beamlines will use the standard MongoDB backend for headers forever, but HXN might experiment with a more performant backend for events.

This adds the possibility of having separate MDS-like objects for the header documents and the event documents. If a separate "EventStore" object is specified, that object is used for all calls to `get_events_generator` and `get_events_table`. If not, the MDS object is used as now.

There are not implementations of `EventStore` per se, and I don't plan to start making more alternative backends any time soon. But whenever someone gets around to it it would be good to have this flexibility in Broker ready and widely deployed.