### PR TITLE
TST: test double access of table

### DIFF
--- a/databroker/tests/conftest.py
+++ b/databroker/tests/conftest.py
@@ -2,24 +2,27 @@ import sys
 import pytest
 
 from databroker.tests.utils import (build_sqlite_backed_broker,
-                                    build_pymongo_backed_broker)
+                                    build_pymongo_backed_broker,
+                                    build_json_backed_broker)
 
 if sys.version_info >= (3, 0):
     from bluesky.tests.conftest import fresh_RE as RE
 
 
-@pytest.fixture(params=['sqlite', 'mongo'], scope='function')
+@pytest.fixture(params=['sqlite', 'mongo', 'json'], scope='function')
 def db(request):
     param_map = {'sqlite': build_sqlite_backed_broker,
-                 'mongo': build_pymongo_backed_broker}
+                 'mongo': build_pymongo_backed_broker,
+                 'json': build_json_backed_broker}
 
     return param_map[request.param](request)
 
 
-@pytest.fixture(params=['sqlite', 'mongo'], scope='function')
+@pytest.fixture(params=['sqlite', 'mongo', 'json'], scope='function')
 def broker_factory(request):
     "Use this to get more than one broker in a test."
     param_map = {'sqlite': lambda: build_sqlite_backed_broker(request),
-                 'mongo': lambda: build_pymongo_backed_broker(request)}
+                 'mongo': lambda: build_pymongo_backed_broker(request),
+                 'json': lambda: build_json_backed_broker(request)}
 
     return param_map[request.param]

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -196,6 +196,16 @@ def test_table_alignment(db, RE):
 
 
 @py3
+def test_double_table(db, RE):
+    RE.subscribe('all', db.insert)
+    uid, = RE(count([det]))
+    table = db.get_table(db[uid])
+    assert table.notnull().all().all()
+    table = db.get_table(db[uid])
+    assert table.notnull().all().all()
+
+
+@py3
 def test_scan_id_lookup(db, RE):
     RE.subscribe('all', db.insert)
 


### PR DESCRIPTION
Ran across an issue where the databroker returns empty tables if you ask it for the same table twice. I am trying to test it.
Note that this is using a mongoquery backend although I think this may be a problem with `AD_TIFF`.