### PR TITLE
API: Make HeaderSource lazy so that Results can be lazy as well.

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import itertools
 import warnings
 import six  # noqa
 import uuid
@@ -253,7 +254,8 @@ class Results(object):
         self._data_key = data_key
 
     def __iter__(self):
-        for start, stop in self._res:
+        self._res, res = itertools.tee(self._res)
+        for start, stop in res:
             header = Header(start=start, stop=stop, db=self._db)
             if self._data_key is None:
                 yield header

--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -1099,10 +1099,8 @@ class HeaderSourceShim(object):
             _format_time(kwargs, self.mds.config['timezone'])
             query = {'$and': [{}] + [kwargs] + filters}
 
-        starts = tuple(self.mds.find_run_starts(**query))
-
-        stops = tuple(_safe_get_stop(self, s) for s in starts)
-        return zip(starts, stops)
+        starts = self.mds.find_run_starts(**query)
+        return ((s, _safe_get_stop(self, s)) for s in starts)
 
     def __getitem__(self, k):
         return search(k, self)

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -664,3 +664,15 @@ def test_export_size_smoke(broker_factory, RE):
     db1.fs.register_handler('RWFS_NPY', ReaderWithFSHandler)
     size = db1.export_size(db1[uid])
     assert size > 0.
+
+
+@py3
+def test_results_multiple_iters(db, RE):
+    RE.subscribe('all', db.insert)
+    RE(count([det]))
+    RE(count([det]))
+    res = db()
+    first = list(res)  # First pass through Result is lazy.
+    second = list(res)  # The Result object's tee should cache results.
+    third = list(res)  # The Result object's tee should cache results.
+    assert first == second == third

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -183,7 +183,7 @@ def test_full_text_search(db, RE):
     assert len(list(db())) == 2
 
     try:
-        db('some words')
+        list(db('some words'))
     except NotImplementedError:
         raise pytest.skip("This mongo-like backend does not support $text.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+attrs
+boltons
+doct
+numpy
+pandas
+pims
+requests
+six
+toolz
+tzlocal

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+with open(path.join(here, 'requirements.txt')) as f:
+    requirements = f.read().split()
+
 setup(
     name='databroker',
     version=versioneer.get_version(),
@@ -27,8 +30,7 @@ setup(
 
     license='BSD (3-clause)',
 
-    install_requires=('attrs', 'cytoolz', 'pandas', 'doct', 'pims',
-                      'requests', 'six', 'boltons', 'numpy'),
+    install_requires=requirements,
 
     classifiers=[
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
#158 did not actually finish the job of making `Broker.__call__` lazy! As @tacaswell mused aloud in the car this morning, there is a call to `tuple()` in the new `HeaderSource` code that materializes the mongo query before it gets to `Broker.__call__`. This PR finishes the job. It is technically API changes on `HeaderSource`. I advocate tagging (yet another) micro release and pushing this to the floor so that databroker-browser can be responsive.

I also threw in a commit to refactor the dependencies into a requirements.txt and add a missing one. This is a little bit unnecessary but it does no harm.