### PR TITLE
MNT: support descriptors with out 'name'

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -199,7 +199,7 @@ def get_fields(header, name=None):
     """
     fields = set()
     for descriptor in header['descriptors']:
-        if name is not None and name != descriptor.get('name'):
+        if name is not None and name != descriptor.get('name', 'primary'):
             continue
         for field in descriptor['data_keys'].keys():
             fields.add(field)
@@ -487,7 +487,7 @@ class EventSourceShim(object):
         return self.mds.insert(name, doc)
 
     def stream_names_given_header(self, header):
-        return set(d['name'] for d in
+        return set(d.get('name', 'primary') for d in
                    self.descriptors_given_header(header))
 
     def fields_given_header(self, header):
@@ -500,7 +500,8 @@ class EventSourceShim(object):
         try:
             return [d
                     for d in self.mds.descriptors_by_start(header.start['uid'])
-                    if stream_name is ALL or d['name'] == stream_name]
+                    if (stream_name is ALL or
+                        d.get('name', 'primary') == stream_name)]
         except self.NoEventDescriptors:
             return []
 

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -40,6 +40,20 @@ def test_uid_roundtrip(db, RE):
 
 
 @py3
+def test_no_descriptor_name(db, RE):
+    def local_insert(name, doc):
+        doc.pop('name', None)
+        return db.insert(name, doc)
+    RE.subscribe('all', local_insert)
+    uid, = RE(count([det]))
+    h = db[uid]
+    db.get_fields(h, name='primary')
+    assert h['start']['uid'] == uid
+    assert len(h.descriptors) == 1
+    assert h.stream_names == ['primary']
+
+
+@py3
 def test_uid_list_multiple_headers(db, RE):
     RE.subscribe('all', db.insert)
     uids = RE(pchain(count([det]), count([det])))


### PR DESCRIPTION
Assume they are in the 'primary' stream

closes #163 