### PR TITLE
TST: add next test

### DIFF
--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -690,3 +690,12 @@ def test_results_multiple_iters(db, RE):
     second = list(res)  # The Result object's tee should cache results.
     third = list(res)  # The Result object's tee should cache results.
     assert first == second == third
+
+
+@py3
+def test_results_next(db, RE):
+    RE.subscribe('all', db.insert)
+    RE(count([det]))
+    RE(count([det]))
+    res = db()
+    assert next(res)


### PR DESCRIPTION
I assume I should be able to use next on the databroker `Results`.