### PR TITLE
FIX: Consistently access header fields using __getitem__ not __getattr__.

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -262,7 +262,7 @@ class Results(object):
             else:
                 # Only include this header in the result if `data_key` is found
                 # in one of its descriptors' data_keys.
-                for descriptor in header.descriptors:
+                for descriptor in header['descriptors']:
                     if self._data_key in descriptor['data_keys']:
                         yield header
                         break

--- a/databroker/core.py
+++ b/databroker/core.py
@@ -498,8 +498,8 @@ class EventSourceShim(object):
 
     def descriptors_given_header(self, header, stream_name=ALL):
         try:
-            return [d
-                    for d in self.mds.descriptors_by_start(header.start['uid'])
+            return [d for d in
+                    self.mds.descriptors_by_start(header['start']['uid'])
                     if (stream_name is ALL or
                         d.get('name', 'primary') == stream_name)]
         except self.NoEventDescriptors:
@@ -546,10 +546,10 @@ class EventSourceShim(object):
 
         descs = self.descriptors_given_header(header, stream_name)
 
-        start = header.start
-        stop = header.stop
+        start = header['start']
+        stop = header['stop']
 
-        yield 'start', header.start
+        yield 'start', header['start']
         for d in descs:
             (all_extra_dk, all_extra_data,
              all_extra_ts, discard_fields) = _extract_extra_data(
@@ -584,7 +584,7 @@ class EventSourceShim(object):
 
                 yield 'event', ev
 
-        yield 'stop', header.stop
+        yield 'stop', header['stop']
 
     def table_given_header(self, header, stream_name,
                            fields=None,

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -690,3 +690,14 @@ def test_results_multiple_iters(db, RE):
     second = list(res)  # The Result object's tee should cache results.
     third = list(res)  # The Result object's tee should cache results.
     assert first == second == third
+
+
+@py3
+def test_dict_header(db, RE):
+    # Ensure that we aren't relying on h being a doct as opposed to a dict.
+    RE.subscribe('all', db.insert)
+    RE(count([det]))
+    h, = db()
+    expected = list(db.get_events(h))
+    actual = list(db.get_events(dict(h)))
+    assert actual == expected


### PR DESCRIPTION
Verified that I got them all with grep:

```
$ git grep header.start
$ git grep header.stop
$ git grep header.descriptors
tests/test_broker.py:    assert [] == header.descriptors
```

and added a test for defense against future changes.