### PR TITLE
Add pipeline to Image (FramesSequence) to process on per image basis

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -598,7 +598,7 @@ class BrokerES(object):
             return pd.DataFrame()
 
     def get_images(self, headers, name, handler_registry=None,
-                   handler_override=None):
+                   handler_override=None, pipeline=None):
         """
         Load images from a detector for given Header(s).
 
@@ -625,7 +625,8 @@ class BrokerES(object):
         return Images(mds=self.mds, fs=self.fs, es=self.event_sources[0],
                       headers=headers,
                       name=name, handler_registry=handler_registry,
-                      handler_override=handler_override)
+                      handler_override=handler_override,
+                      pipeline=pipeline)
 
     def get_resource_uids(self, header):
         '''Given a Header, give back a list of resource uids

--- a/databroker/pims_readers.py
+++ b/databroker/pims_readers.py
@@ -3,7 +3,7 @@ from .core import Images as _Images
 
 
 def get_images(headers, name, handler_registry=None,
-               handler_override=None):
+               handler_override=None, pipeline=None):
     """
     Load images from a detector for given Header(s).
 
@@ -28,7 +28,8 @@ def get_images(headers, name, handler_registry=None,
     """
     res = DataBroker.get_images(headers=headers, name=name,
                                 handler_registry=handler_registry,
-                                handler_override=handler_override)
+                                handler_override=handler_override,
+                                pipeline=pipeline)
     return res
 
 


### PR DESCRIPTION
@danielballan, @tacaswell 
cc @stuartcampbell 

I wanted to add this as a discussion point. I tracked the problem with pipelines, and it comes from handlers that return on a per datum (point) basis a `FramesSequence`. I think this adds the possibility of adding a pipeline at the correct point. 

Thoughts? 

I also though about cleaning up the `__repr__` also. 