### PR TITLE
CLN: Remove old _munge_time, which now lives in databroker.eventsource.archiver.

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -1163,25 +1163,6 @@ class Broker(BrokerES):
         return cls.from_config(lookup_config(name))
 
 
-def _munge_time(t, timezone):
-    """Close your eyes and trust @arkilic
-
-    Parameters
-    ----------
-    t : float
-        POSIX (seconds since 1970)
-    timezone : pytz object
-        e.g. ``pytz.timezone('US/Eastern')``
-
-    Return
-    ------
-    time
-        as ISO-8601 format
-    """
-    t = datetime.fromtimestamp(t)
-    return timezone.localize(t).replace(microsecond=0).isoformat()
-
-
 def _sanitize(doc):
     # Make this a plain dict and strip off doct.Document artifacts.
     d = dict(doc)


### PR DESCRIPTION
Closes #238