### PR TITLE
ENH: Make it safe to insert events with a 'filled' key.

### DIFF
--- a/databroker/headersource/base.py
+++ b/databroker/headersource/base.py
@@ -485,7 +485,7 @@ class MDSTemplate(MDSROTemplate):
                                            **kwargs)
 
     def insert_event(self, descriptor, time, seq_num, data, timestamps, uid,
-                     validate=False):
+                     validate=False, filled=None):
         """Create an event in metadatastore database backend
 
         .. warning
@@ -511,7 +511,14 @@ class MDSTemplate(MDSROTemplate):
             same keys as `data` above
         uid : str
             Globally unique id string provided to metadatastore
+        validate : boolean
+            Check that data and timestamps have the same keys.
+        filled : dict or None
+            Dictionary of `False` or datum_ids. Keys are a subset of the keys
+            in `data` and `timestamps` above.
         """
+        if filled is None:
+            filled = {}
         for k, v in data.items():
             data[k] = sanitize_np(v)
 
@@ -521,6 +528,7 @@ class MDSTemplate(MDSROTemplate):
                                       data=data,
                                       timestamps=timestamps,
                                       uid=uid,
+                                      filled=filled,
                                       validate=validate)
 
     def bulk_insert_events(self, descriptor, events, validate=False):

--- a/databroker/headersource/client.py
+++ b/databroker/headersource/client.py
@@ -673,7 +673,7 @@ class MDS(MDSRO):
         return uid
 
     def insert_event(self, descriptor, time, seq_num, data, timestamps,
-                     uid, validate=False):
+                     uid, validate=False, filled=None):
         """Create an event in metadatastore database backend
 
         .. warning
@@ -699,7 +699,19 @@ class MDS(MDSRO):
             same keys as `data` above
         uid : str
             Globally unique id string provided to metadatastore
+        validate : boolean
+            Check that data and timestamps have the same keys.
+        filled : dict
+            Dictionary of `False` or datum_ids. Keys are a subset of the keys
+            in `data` and `timestamps` above.
         """
+        data = dict(data)
+        # Replace any filled data with the datum_id stashed in 'filled'.
+        if filled is None:
+            filled = {}
+        for k, v in six.iteritems(filled):
+            if v:
+                data[k] = v
         for k, v in data.items():
             data[k] = _sanitize_np(v)
         if validate:
@@ -740,11 +752,16 @@ class MDS(MDSRO):
                         raise ValueError(
                             BAD_KEYS_FMT.format(ev['data'].keys(),
                                                 ev['timestamps'].keys()))
+                data = dict(data)
+                # Replace any filled data with the datum_id stashed in 'filled'.
+                for k, v in six.iteritems(event.get('filled', {})):
+                    if v:
+                        data[k] = v
                 descriptor_uid = self.doc_or_uid_to_uid(descriptor)
                 ev_out = dict(descriptor=descriptor_uid, uid=ev['uid'],
-                            data=ev['data'], timestamps=ev['timestamps'],
-                            time=ev['time'],
-                            seq_num=ev['seq_num'])
+                              data=data, timestamps=ev['timestamps'],
+                              time=ev['time'],
+                              seq_num=ev['seq_num'])
                 yield ev_out
         d = list(event_factory())
         payload = self.datafactory(data=dict(descriptor=descriptor, events=events,

--- a/databroker/headersource/client.py
+++ b/databroker/headersource/client.py
@@ -740,10 +740,6 @@ class MDS(MDSRO):
         ret : dict
             dictionary of details about the insertion
         """
-        events = list(events) # if iterator, make json serializable
-        for e in events:
-            for k, v in e['data'].items():
-                e['data'][k] = _sanitize_np(v)
         def event_factory():
             for ev in events:
                 # check keys, this could be expensive

--- a/databroker/headersource/mongo_core.py
+++ b/databroker/headersource/mongo_core.py
@@ -96,15 +96,20 @@ def bulk_insert_events(event_col, descriptor, events, validate):
 
     def event_factory():
         for ev in events:
+            data = dict(ev['data'])
+            # Replace any filled data with the datum_id stashed in 'filled'.
+            for k, v in six.iteritems(event.get('filled', {})):
+                if v:
+                    data[k] = v
             # check keys, this could be expensive
             if validate:
-                if ev['data'].keys() != ev['timestamps'].keys():
+                if data.keys() != ev['timestamps'].keys():
                     raise ValueError(
                         BAD_KEYS_FMT.format(ev['data'].keys(),
                                             ev['timestamps'].keys()))
 
             ev_out = dict(descriptor=descriptor_uid, uid=ev['uid'],
-                          data=ev['data'], timestamps=ev['timestamps'],
+                          data=data, timestamps=ev['timestamps'],
                           time=ev['time'],
                           seq_num=ev['seq_num'])
             yield ev_out

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -947,3 +947,71 @@ def test_data_method(db, RE):
     actual = list(h.data('det'))
     expected = [1, 1, 1, 1, 1]
     assert actual == expected
+
+
+def test_extraneous_filled_stripped_on_insert(db, RE):
+
+    # TODO It would be better if this errored, but at the moment
+    # this would required looking up the event descriptor.
+
+    # Hack the Event so it does not match its Event Descriptor.
+    def insert(name, doc):
+        if name == 'event':
+            doc['filled'] = {'det': False}
+            assert 'filled' in doc
+        db.insert(name, doc)
+
+    RE.subscribe(insert)
+
+    uid, = RE(count([det]))
+    h = db[uid]
+
+    # expect event['filled'] == {}
+    for ev in h.events():
+        assert not ev['filled']
+
+
+@py3
+def test_filled_false_stripped_on_insert(db, RE):
+    # Hack the Event and the Descriptor consistently.
+    def insert(name, doc):
+        if name == 'event':
+            doc['filled'] = {'det': False}
+            doc['data']['det'] = 'DATUM_ID_PLACEHOLDER'
+            assert 'filled' in doc
+        elif name == 'descriptor':
+            doc['data_keys']['det']['external'] = 'PLACEHOLDER'
+        db.insert(name, doc)
+
+    RE.subscribe(insert)
+
+    uid, = RE(count([det]))
+    h = db[uid]
+
+    # expect event['filled'] == {'det': False}
+    for ev in h.events():
+        assert 'det' in ev['filled']
+        assert not ev['filled']['det']
+        assert ev['data']['det'] == 'DATUM_ID_PLACEHOLDER'
+
+
+def test_filled_true_rotated_on_insert(db, RE):
+    # Hack the Event and the Descriptor consistently.
+    def insert(name, doc):
+        if name == 'event':
+            doc['filled'] = {'det': 'DATUM_ID_PLACEHOLDER'}
+            assert 'filled' in doc
+        elif name == 'descriptor':
+            doc['data_keys']['det']['external'] = 'PLACEHOLDER'
+        db.insert(name, doc)
+
+    RE.subscribe(insert)
+
+    uid, = RE(count([det]))
+    h = db[uid]
+
+    # expect event['filled'] == {'det': False}
+    for ev in h.events():
+        assert 'det' in ev['filled']
+        assert not ev['filled']['det']
+        assert ev['data']['det'] == 'DATUM_ID_PLACEHOLDER'


### PR DESCRIPTION
A prerequisite for https://github.com/NSLS-II/bluesky/issues/661

An event with ``filled={'some_key': False}`` will have its filled
item stripped off.

An event with ``filled={'some_key': 'some_datum_id'}`` will be
inserted with ``data={'some_key': 'some_datum_id'}`` instead of
the filled data being used.