### PR TITLE
FIX: Fixed location of handlers, was pulling from filestore

### DIFF
--- a/databroker/core.py
+++ b/databroker/core.py
@@ -401,11 +401,11 @@ class Header(object):
 
 def register_builtin_handlers(fs):
     "Register all the handlers built in to filestore."
-    from filestore import handlers, HandlerBase
+    from .assets import handlers
     # TODO This will blow up if any non-leaves in the class heirarchy
     # have non-empty specs. Make this smart later.
     for cls in vars(handlers).values():
-        if isinstance(cls, type) and issubclass(cls, HandlerBase):
+        if isinstance(cls, type) and issubclass(cls, handlers.HandlerBase):
             logger.debug("Found Handler %r for specs %r", cls, cls.specs)
             for spec in cls.specs:
                 logger.debug("Registering Handler %r for spec %r", cls, spec)


### PR DESCRIPTION
@tacaswell @danielballan @stuartcampbell 

I noticed that the current `register_builtin_handlers` was pulling from `filestore`. This confused me for a while because it was pulling from the old filestore package and not the handlers packaged with `databroker`. 

This fixes that. 

However there still needs to be a call to auto-register the handlers......