### PR TITLE
API: deprecate Broker.fill_event

### DIFF
--- a/databroker/broker.py
+++ b/databroker/broker.py
@@ -624,6 +624,8 @@ class BrokerES(object):
 
     def fill_event(self, event, inplace=True, handler_registry=None):
         """
+        Deprecated, use `fill_events` instead.
+
         Populate events with externally stored data.
 
         Parameters
@@ -635,6 +637,8 @@ class BrokerES(object):
         handler_registry : dict, optional
             mapping spec names (strings) to handlers (callable classes)
         """
+        warnings.warn("fill_event is deprecated, use fill_events instead",
+                      stacklevel=2)
         # TODO sort out how to (quickly) map events back to the
         # correct event Source
         desc_id = event['descriptor']


### PR DESCRIPTION
 - fill_events in more general
 - because documents are no longer dereferenced, `fill_event` either
   needs to search for descriptors or the API needs to change for
   descriptors to be passed in
 - The setup for filling may be non-trivial