### PR TITLE
ENH: Support correct location for Windows config

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -840,18 +840,22 @@ class Results(object):
                         yield header
                         break
 
-# Search order is:
-# ~/.config/databroker
-# <sys.executable directory>/../etc/databroker
-# /etc/databroker
+# Search order is (for unix):
+#   ~/.config/databroker
+#   <sys.executable directory>/../etc/databroker
+#   /etc/databroker
+# And for Windows we only look in:
+#   %APPDATA%/databroker
 
-
-_user_conf = os.path.join(os.path.expanduser('~'), '.config', 'databroker')
-_local_etc = os.path.join(os.path.dirname(os.path.dirname(sys.executable)),
-                          'etc', 'databroker')
-_system_etc = os.path.join('/', 'etc', 'databroker')
-CONFIG_SEARCH_PATH = (_user_conf, _local_etc, _system_etc)
-
+if os.name == 'nt':
+    _user_conf = os.path.join(os.environ['APPDATA'], 'databroker')
+    CONFIG_SEARCH_PATH = (_user_conf)
+else:
+    _user_conf = os.path.join(os.path.expanduser('~'), '.config', 'databroker')
+    _local_etc = os.path.join(os.path.dirname(os.path.dirname(sys.executable)),
+                              'etc', 'databroker')
+    _system_etc = os.path.join('/', 'etc', 'databroker')
+    CONFIG_SEARCH_PATH = (_user_conf, _local_etc, _system_etc)
 
 if six.PY2:
     FileNotFoundError = IOError

--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -849,7 +849,7 @@ class Results(object):
 
 if os.name == 'nt':
     _user_conf = os.path.join(os.environ['APPDATA'], 'databroker')
-    CONFIG_SEARCH_PATH = (_user_conf)
+    CONFIG_SEARCH_PATH = (_user_conf,)
 else:
     _user_conf = os.path.join(os.path.expanduser('~'), '.config', 'databroker')
     _local_etc = os.path.join(os.path.dirname(os.path.dirname(sys.executable)),


### PR DESCRIPTION
Instead of just using .config in the users folder we now use the correct Windows location
i.e. `%APPDATA%`

I haven't full tested this on Windows yet - having some issues getting all the dependencies working under Windows, namely `ujson` at the moment (I would need to install Visual Studio!).  I think for this release a code review and working for unix is good enough ?

closes #279 