### PR TITLE
API: Tweak list_configs()

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -49,6 +49,10 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+SPECIAL_NAME = '_legacy_config'
+if 'DATABROKER_TEST_MODE' in os.environ:
+    SPECIAL_NAME = '_test_legacy_config'
+
 
 class InvalidDocumentSequence(Exception):
     pass
@@ -884,10 +888,14 @@ def list_configs():
     --------
     :func:`describe_configs`
     """
-    names = []
+    names = set()
     for path in CONFIG_SEARCH_PATH:
         files = glob.glob(os.path.join(path, '*.yml'))
-        names.extend([os.path.basename(f)[:-4] for f in files])
+        names.update([os.path.basename(f)[:-4] for f in files])
+
+    # Do not include _legacy_config.
+    names.discard(SPECIAL_NAME)
+
     return sorted(names)
 
 

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -6,16 +6,12 @@
 # This module look for a specially-named configuration file and generates a
 # special instance of Broker to avoid breaking old user code.
 
-from ._core import Broker, lookup_config
+from ._core import Broker, lookup_config, SPECIAL_NAME
 from ._core import get_fields  # unused, but here for API compat
 from functools import wraps
 import os
 import six
 from warnings import warn
-
-SPECIAL_NAME = '_legacy_config'
-if 'DATABROKER_TEST_MODE' in os.environ:
-    SPECIAL_NAME = '_test_legacy_config'
 
 if six.PY2:
     FileNotFoundError = IOError


### PR DESCRIPTION
- Do not include `'_legacy_config'` in `list_configs()` output. It is
  redundant and (empirically) confuses users.
- Remove duplicate names. Search path precedence will shadow duplicates.