### PR TITLE
PERF: Do not call check_fields_exist inside get_documents.

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -1528,7 +1528,6 @@ class BrokerES(object):
         else:
             headers = [headers]
 
-        check_fields_exist(fields if fields else [], headers)
         # dirty hack!
         with self.reg.handler_context(handler_registry):
             for h in headers:

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -162,9 +162,6 @@ def test_get_events_filtering_field(db, RE):
     assert len(list(db.get_events(h, fields=['det']))) == 7
     assert len(list(h.documents(fields=['det']))) == 7 + 3
 
-    with pytest.raises(ValueError):
-        list(db.get_events(h, fields=['not_a_field']))
-
     uids = RE(pchain(count([det1], num=7), count([det2], num=3)))
     headers = db[uids]
 


### PR DESCRIPTION
The purpose of this line was to alert the user if none of the headers
had a field that the user requested. This of course requires greedily
checking all of the headers, which breaks the laziness of Results.
Based on benchmarking by @ordirules, it can take > 5 minutes to get
the first result out of month's worth of data. Removing this line
reduces that time to < 1 second.