### PR TITLE
API: return {} instead of None if missing stop document

### DIFF
--- a/databroker/headersource/shim.py
+++ b/databroker/headersource/shim.py
@@ -62,4 +62,4 @@ def safe_get_stop(hs, s):
     try:
         return hs.stop_by_start(s)
     except hs.NoRunStop:
-        return None
+        return {}


### PR DESCRIPTION
This changes the HeaderSource behavior to match the default in the
Header constructor.

This needs tests + discussion

atn @ordirules