### PR TITLE
STY: changed syntax

### DIFF
--- a/databroker/tests/conftest.py
+++ b/databroker/tests/conftest.py
@@ -19,7 +19,8 @@ import databroker.headersource.mongoquery as mqmds
 from ..headersource import sqlite as sqlmds
 
 if sys.version_info >= (3, 5):
-    from bluesky.tests.conftest import RE as RE
+    # this is a pytest.fixture
+    from bluesky.tests.conftest import RE
 
     @pytest.fixture(scope='function')
     def hw(request):


### PR DESCRIPTION
suggested. 
This came from 
```
git diff 8940dc1fc3f16dd76611e389338282739a1ef8e4 1bfed85adfec9b7f89db2adf4ec600dd328371b9
-    from bluesky.tests.conftest import fresh_RE as RE
+    from bluesky.tests.conftest import RE as RE
```
