### PR TITLE
MNT/API: remove unintended API for accessing methods

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -112,9 +112,9 @@ class Header(object):
     ### dict-like methods ###
 
     def __getitem__(self, k):
-        try:
+        if k in ('start', 'descriptors', 'stop'):
             return getattr(self, k)
-        except AttributeError as e:
+        else:
             raise KeyError(k)
 
     def get(self, *args, **kwargs):

--- a/databroker/databroker.py
+++ b/databroker/databroker.py
@@ -22,7 +22,7 @@ def deprecate(f):
     def inner(*args, **kwargs):
         name = getattr(f, '__name__', '')  # works on py3.5+
         warn("This function {} is deprecated. Use a method on Broker instead."
-            "".format(name))
+             "".format(name))
         return f(*args, **kwargs)
     return inner
 

--- a/databroker/headersource/mongoquery.py
+++ b/databroker/headersource/mongoquery.py
@@ -16,7 +16,7 @@ class JSONCollection(object):
     def refresh(self):
         if os.path.isfile(self._fp):
             with open(self._fp, 'r') as f:
-                self._docs= json.load(f)
+                self._docs = json.load(f)
         else:
             self._docs = []
             with open(self._fp, 'w') as f:

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -749,6 +749,12 @@ def test_dict_header(db, RE):
     actual = list(db.get_events(dict(h)))
     assert actual == expected
 
+    h['start']
+    h['stop']
+    h['descriptors']
+    with pytest.raises(KeyError):
+        h['events']
+
 
 @py3
 def test_config_data(db, RE):


### PR DESCRIPTION
`__getitem__` was too flexible and would return methods as well
as the {'start', 'stop', 'descriptors'} as required to shim dictionary
behavior.

closes #307