### PR TITLE
Doc Add version sentinels

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -2,9 +2,12 @@
 Configuration
 *************
 
+
 Configuration files make it easy to quickly set up :class:`Broker` instances
 with the expression ``Broker.named('example')`` where 'example' is the name of
 a configuration file.
+
+.. _configuration_doc:
 
 Search Path
 -----------

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -2,12 +2,9 @@
 Configuration
 *************
 
-
 Configuration files make it easy to quickly set up :class:`Broker` instances
 with the expression ``Broker.named('example')`` where 'example' is the name of
 a configuration file.
-
-.. _configuration_doc:
 
 Search Path
 -----------

--- a/doc/source/creating.rst
+++ b/doc/source/creating.rst
@@ -1,0 +1,29 @@
+***********************
+Creating a New Database
+***********************
+
+In some cases, you may want to create a new database. Currently, storage and
+retrieval is implemented in MongoDB so instructions for MongoDB will follow.
+The implementation for other types of databases is likely similar.
+
+Creation in MongoDB
+-------------------
+
+The creation of a database in MongoDB is simple. Simply create a configuration
+as described in :ref:`configuration`. The only requirement is that the MongoDB
+instance is running on the machine specified. The database need not exist yet.
+The next step is to install a version sentinel. This is done as follows:
+
+.. code-block:: python
+
+    # Instantiate databroker instance
+    from databroker import Broker
+    db_analysis = Broker.named(config_name)
+
+    # install sentinels
+    databroker.assets.utils.install_sentinels(db_analysis.reg.config,
+                                              version=1)
+
+where ``config_name`` is the name of your configuration and ``version=1`` refers
+to the version of filestore you are using (it is currently ``1`` as of this
+writing).

--- a/doc/source/creating.rst
+++ b/doc/source/creating.rst
@@ -10,7 +10,7 @@ Creation in MongoDB
 -------------------
 
 The creation of a database in MongoDB is simple. Simply create a configuration
-as described in :ref:`configuration_doc`. The only requirement is that the MongoDB
+as described in :doc:`configuration`. The only requirement is that the MongoDB
 instance is running on the machine specified. The database need not exist yet.
 The next step is to install a version sentinel. This is done as follows:
 
@@ -24,6 +24,6 @@ The next step is to install a version sentinel. This is done as follows:
     databroker.assets.utils.install_sentinels(db_analysis.reg.config,
                                               version=1)
 
-where ``config_name`` is the name of your configuration and ``version=1`` refers
-to the version of filestore you are using (it is currently ``1`` as of this
-writing).
+where ``config_name`` is the name of your configuration and ``version=1``
+refers to the version of asset registry you are using (it is currently ``1`` as
+of this writing).

--- a/doc/source/creating.rst
+++ b/doc/source/creating.rst
@@ -10,7 +10,7 @@ Creation in MongoDB
 -------------------
 
 The creation of a database in MongoDB is simple. Simply create a configuration
-as described in :ref:`configuration`. The only requirement is that the MongoDB
+as described in :ref:`configuration_doc`. The only requirement is that the MongoDB
 instance is running on the machine specified. The database need not exist yet.
 The next step is to install a version sentinel. This is done as follows:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,4 +18,5 @@ Index
     tutorial
     api
     configuration
+    creating
     whats_new


### PR DESCRIPTION
I think we need this somewhere (discussion about version sentinels). This is a suggestion, feel free to overtake it. 

When I build by the way, I get a few unrelated warnings:
(for ex: doc/source/_as_gen/databroker.Header.values.rst: WARNING: document isn't included in any toctre)

@danielballan 