### PR TITLE
ENH: Support Broker.named('temp')

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -2161,6 +2161,12 @@ class Broker(BrokerES):
         where ``{python}`` is the location of the current Python binary, as
         reported by ``sys.executable``. It will use the first match it finds.
 
+        Special Case: The name ``'temp'`` creates a new, temporary
+        configuration. Subsequent calls to ``Broker.named('temp')`` will
+        create separate configurations. Any data saved using this temporary
+        configuration will not be accessible once the ``Broker`` instance has
+        been deleted.
+
         Parameters
         ----------
         name : string
@@ -2173,7 +2179,11 @@ class Broker(BrokerES):
         -------
         db : Broker
         """
-        db = cls.from_config(lookup_config(name), auto_register=auto_register)
+        if name == 'temp':
+            config = temp_config()
+        else:
+            config = lookup_config(name)
+        db = cls.from_config(config, auto_register=auto_register)
         return db
 
 

--- a/databroker/tests/test_config.py
+++ b/databroker/tests/test_config.py
@@ -157,3 +157,14 @@ def test_temp_config():
     db.insert('start', {'uid': uid, 'time': 0})
     db.insert('stop', {'uid': str(uuid.uuid4()), 'time': 1, 'run_start': uid})
     db[-1]
+
+
+def test_named_temp():
+    db = Broker.named('temp')
+    uid = str(uuid.uuid4())
+    db.insert('start', {'uid': uid, 'time': 0})
+    db.insert('stop', {'uid': str(uuid.uuid4()), 'time': 1, 'run_start': uid})
+    db[-1]
+
+    db2 = Broker.named('temp')
+    assert db.mds.config != db2.mds.config


### PR DESCRIPTION
This makes 'temp' a special name so that

```python
Broker.named('temp')
```

is equivalent to

```python
Broker.from_config(temp_config())
```

It provides a nice escape hatch for entry points that only accept
names, not config dicts, such as this one:

```python
configure_base(get_ipython().user_ns, 'temp')
```