### PR TITLE
BUG: removed invalid kwarg to get_images

### DIFF
--- a/databroker/pims_readers.py
+++ b/databroker/pims_readers.py
@@ -20,9 +20,6 @@ def get_images(headers, name, handler_registry=None):
         field name (data key) of a detector
     handler_registry : dict, optional
         mapping spec names (strings) to handlers (callable classes)
-    handler_override : callable class, optional
-        overrides registered handlers
-
 
     Example
     -------
@@ -32,8 +29,7 @@ def get_images(headers, name, handler_registry=None):
             # do something
     """
     res = DataBroker.get_images(headers=headers, name=name,
-                                handler_registry=handler_registry,
-                                handler_override=handler_override)
+                                handler_registry=handler_registry)
     return res
 
 

--- a/databroker/pims_readers.py
+++ b/databroker/pims_readers.py
@@ -6,8 +6,7 @@ from .databroker import DataBroker
 from ._core import Images as _Images
 
 
-def get_images(headers, name, handler_registry=None,
-               handler_override=None):
+def get_images(headers, name, handler_registry=None):
     """
     This function is deprecated. Use Header.data instead.
 


### PR DESCRIPTION
@yugangzhang's code still uses `get_images` in some places. We're working to move away from that. However, in the meantime, could we fix the deprecated function? `handler_override` is no loonger an acccepted kwarg thanks!