### PR TITLE
Rename start_time, end_time -> since, until.

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -1128,8 +1128,8 @@ class BrokerES(object):
 
     def _format_time(self, val):
         "close over the timezone config"
-        # modifies a query dict in place, remove keys 'start_time' and
-        # 'stop_time' and adding $lte and/or $gte queries on 'time' key
+        # modifies a query dict in place, remove keys 'since' and
+        # 'until' and adding $lte and/or $gte queries on 'time' key
         format_time(val, self.hs.mds.config['timezone'])
 
     @property
@@ -1158,7 +1158,7 @@ class BrokerES(object):
         March 2017.
 
         >>> db.add_filter(user='Dan')
-        >>> db.add_filter(start_time='2017-3')
+        >>> db.add_filter(since='2017-3')
 
         The following query is equivalent to
         ``db(user='Dan', plan_name='scan')``.
@@ -1168,7 +1168,7 @@ class BrokerES(object):
         Review current filters.
 
         >>> db.filters
-        {'user': 'Dan', 'start_time': '2017-3'}
+        {'user': 'Dan', 'since': '2017-3'}
 
         Clear filters.
 
@@ -1295,8 +1295,7 @@ class BrokerES(object):
 
         >>> import time
         >>> db.dynamic_alias('today',
-        ...                  lambda: {'start_time':
-        ...                           start_time=time.time()- 24*60*60})
+        ...                  lambda: {'since': time.time() - 24*60*60})
 
         Use it.
 
@@ -1325,7 +1324,7 @@ class BrokerES(object):
         addition to the Parameters below, advanced users can specifiy arbitrary
         queries using the MongoDB query syntax.
 
-        The ``start_time`` and ``stop_time`` parameters accepts the following
+        The ``since`` and ``until`` parameters accepts the following
         representations of time:
 
         * timestamps like ``time.time()`` and ``datetime.datetime.now()``
@@ -1338,9 +1337,9 @@ class BrokerES(object):
         ----------
         text_search : str, optional
             search full text of RunStart documents
-        start_time : str, optional
+        since: str, optional
             Restrict results to runs that started after this time.
-        stop_time : str, optional
+        until : str, optional
             Restrict results to runs that started before this time.
         data_key : str, optional
             Restrict results to runs that contained this data_key (a.k.a field)
@@ -1370,7 +1369,7 @@ class BrokerES(object):
 
         Search by time range. (These keywords have a special meaning.)
 
-        >>> db(start_time='2015-03-05', stop_time='2015-03-10')
+        >>> db(since='2015-03-05', until='2015-03-10')
 
         Perform text search on all values in the Run Start document.
 

--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -1126,22 +1126,6 @@ class BrokerES(object):
 
     ALL = ALL  # sentinel used as default value for `stream_name`
 
-    def _format_time(self, val):
-        "close over the timezone config"
-        # modifies a query dict in place, remove keys 'since' and
-        # 'until' and adding $lte and/or $gte queries on 'time' key
-        format_time(val, self.hs.mds.config['timezone'])
-
-    @property
-    def filters(self):
-        return self._filters
-
-    @filters.setter
-    def filters(self, val):
-        for elem in val:
-            self._format_time(elem)
-        self._filters = val
-
     def add_filter(self, **kwargs):
         """
         Add query to the list of 'filter' queries.

--- a/databroker/eventsource/archiver.py
+++ b/databroker/eventsource/archiver.py
@@ -55,15 +55,15 @@ class ArchiverEventSource(object):
             # Mock up descriptors and cache them so that the ephemeral uid is
             # stable for the duration of this process.
             descs = []
-            start_time = header['start']['time'],
-            stop_time = header['stop']['time']
+            since = header['start']['time'],
+            until = header['stop']['time']
             for name, pv in six.iteritems(self.pvs):
                 data_keys = {name: {'source': pv,
                                     'dtype': 'number',
                                     'shape': []}}
-                _from = _munge_time(start_time[0], self.tz)
-                # because start_time is a tuple^
-                _to = _munge_time(stop_time, self.tz)
+                _from = _munge_time(since[0], self.tz)
+                # because since is a tuple^
+                _to = _munge_time(until, self.tz)
                 params = {'pv': pv, 'from': _from, 'to': _to}
                 desc = {'time': header['start']['time'],
                         'uid': 'empheral-' + str(uuid.uuid4()),
@@ -85,10 +85,10 @@ class ArchiverEventSource(object):
             pv = list(d['data_keys'].values())[0]['source']
             desc_uids[pv] = d['uid']
             yield d
-        start_time, stop_time = header['start']['time'], header['stop']['time']
+        since, until = header['start']['time'], header['stop']['time']
         for name, pv in six.iteritems(self.pvs):
-            _from = _munge_time(start_time, self.tz)
-            _to = _munge_time(stop_time, self.tz)
+            _from = _munge_time(since, self.tz)
+            _to = _munge_time(until, self.tz)
             params = {'pv': pv, 'from': _from, 'to': _to}
             req = requests.get(self.archiver_addr, params=params, stream=True)
             req.raise_for_status()

--- a/databroker/headersource/base.py
+++ b/databroker/headersource/base.py
@@ -230,7 +230,7 @@ class MDSROTemplate(object):
 
         Parameters
         ----------
-        start_time : time-like, optional
+        since : time-like, optional
             time-like representation of the earliest time that a RunStart
             was created. Valid options are:
                - timestamps --> time.time()
@@ -239,9 +239,9 @@ class MDSROTemplate(object):
                - '2015-01-30'
                - '2015-03-30 03:00:00'
                - datetime.datetime.now()
-        stop_time : time-like, optional
+        until : time-like, optional
             timestamp of the latest time that a RunStart was created. See
-            docs for `start_time` for examples.
+            docs for `since` for examples.
         beamline_id : str, optional
             String identifier for a specific beamline
         project : str, optional
@@ -260,11 +260,11 @@ class MDSROTemplate(object):
         --------
         >>> find_run_starts(scan_id=123)
         >>> find_run_starts(owner='arkilic')
-        >>> find_run_starts(start_time=1421176750, stop_time=time.time()})
-        >>> find_run_starts(start_time=1421176750, stop_time=time.time())
+        >>> find_run_starts(since=1421176750, until=time.time()})
+        >>> find_run_starts(since=1421176750, until=time.time())
 
-        >>> find_run_starts(owner='arkilic', start_time=1421176750.514707,
-        ...                stop_time=time.time())
+        >>> find_run_starts(owner='arkilic', since=1421176750.514707,
+        ...                until=time.time())
 
         """
         gen = self._api.find_run_starts(self._runstart_col,
@@ -281,7 +281,7 @@ class MDSROTemplate(object):
         ----------
         run_start : doc.Document or str, optional
             The RunStart document or uid to get the corresponding run end for
-        start_time : time-like, optional
+        since : time-like, optional
             time-like representation of the earliest time that a RunStop
             was created. Valid options are:
                - timestamps --> time.time()
@@ -290,9 +290,9 @@ class MDSROTemplate(object):
                - '2015-01-30'
                - '2015-03-30 03:00:00'
                - datetime.datetime.now()
-        stop_time : time-like, optional
+        until : time-like, optional
             timestamp of the latest time that a RunStop was created. See
-            docs for `start_time` for examples.
+            docs for `since` for examples.
         exit_status : {'success', 'fail', 'abort'}, optional
             provides information regarding the run success.
         reason : str, optional
@@ -319,7 +319,7 @@ class MDSROTemplate(object):
         ----------
         run_start : doc.Document or str, optional
             The RunStart document or uid to get the corresponding run end for
-        start_time : time-like, optional
+        since : time-like, optional
             time-like representation of the earliest time that an
             EventDescriptor was created. Valid options are:
                - timestamps --> time.time()
@@ -328,9 +328,9 @@ class MDSROTemplate(object):
                - '2015-01-30'
                - '2015-03-30 03:00:00'
                - datetime.datetime.now()
-        stop_time : time-like, optional
+        until : time-like, optional
             timestamp of the latest time that an EventDescriptor was created.
-            See docs for `start_time` for examples.
+            See docs for `since` for examples.
         uid : str, optional
             Globally unique id string provided to metadatastore
 

--- a/databroker/headersource/client.py
+++ b/databroker/headersource/client.py
@@ -205,7 +205,7 @@ class MDSRO(object):
         """Given search criteria, locate RunStart Documents.
         Parameters
         ----------
-        start_time : time-like, optional
+        since : time-like, optional
         time-like representation of the earliest time that a RunStart
         was created. Valid options are:
             - timestamps --> time.time()
@@ -214,9 +214,9 @@ class MDSRO(object):
             - '2015-01-30'
             - '2015-03-30 03:00:00'
             - datetime.datetime.now()
-        stop_time : time-like, optional
+        until : time-like, optional
             timestamp of the latest time that a RunStart was created. See
-            docs for `start_time` for examples.
+            docs for `since` for examples.
         project : str, optional
             Project name
         owner : str, optional
@@ -230,10 +230,10 @@ class MDSRO(object):
         --------
         >>> find_run_starts(scan_id=123)
         >>> find_run_starts(owner='arkilic')
-        >>> find_run_starts(start_time=1421176750.514707, stop_time=time.time()})
-        >>> find_run_starts(start_time=1421176750.514707, stop_time=time.time())
-        >>> find_run_starts(owner='arkilic', start_time=1421176750.514707,
-        ...                stop_time=time.time())
+        >>> find_run_starts(since=1421176750.514707, until=time.time()})
+        >>> find_run_starts(since=1421176750.514707, until=time.time())
+        >>> find_run_starts(owner='arkilic', since=1421176750.514707,
+        ...                until=time.time())
         """
         params = self.queryfactory(query=kwargs,
                                    signature='find_run_starts')
@@ -247,7 +247,7 @@ class MDSRO(object):
         ----------
         run_start : dict or str, optional
         The RunStart document or uid to get the corresponding run end for
-        start_time : time-like, optional
+        since : time-like, optional
         time-like representation of the earliest time that an EventDescriptor
         was created. Valid options are:
             - timestamps --> time.time()
@@ -256,9 +256,9 @@ class MDSRO(object):
             - '2015-01-30'
             - '2015-03-30 03:00:00'
             - datetime.datetime.now()
-        stop_time : time-like, optional
+        until : time-like, optional
             timestamp of the latest time that an EventDescriptor was created.
-            See docs for `start_time` for examples.
+            See docs for `since` for examples.
         uid : str, optional
             Globally unique id string provided to metadatastore
         Yields
@@ -279,7 +279,7 @@ class MDSRO(object):
         ----------
         run_start : dict or str, optional
             The RunStart document or uid to get the corresponding run end for
-        start_time : time-like, optional
+        since : time-like, optional
             time-like representation of the earliest time that a RunStop
             was created. Valid options are:
             - timestamps --> time.time()
@@ -288,9 +288,9 @@ class MDSRO(object):
             - '2015-01-30'
             - '2015-03-30 03:00:00'
             - datetime.datetime.now()
-        stop_time : time-like, optional
+        until : time-like, optional
             timestamp of the latest time that a RunStop was created. See
-            docs for `start_time` for examples.
+            docs for `since` for examples.
         exit_status : {'success', 'fail', 'abort'}, optional
             provides information regarding the run success.
         reason : str, optional

--- a/databroker/headersource/core.py
+++ b/databroker/headersource/core.py
@@ -782,7 +782,7 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
 
     Parameters
     ----------
-    start_time : time-like, optional
+    since : time-like, optional
         time-like representation of the earliest time that a RunStart
         was created. Valid options are:
            - timestamps --> time.time()
@@ -791,9 +791,9 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
            - '2015-01-30'
            - '2015-03-30 03:00:00'
            - datetime.datetime.now()
-    stop_time : time-like, optional
+    until : time-like, optional
         timestamp of the latest time that a RunStart was created. See
-        docs for `start_time` for examples.
+        docs for `since` for examples.
     beamline_id : str, optional
         String identifier for a specific beamline
     project : str, optional
@@ -812,11 +812,11 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
     --------
     >>> find_run_starts(scan_id=123)
     >>> find_run_starts(owner='arkilic')
-    >>> find_run_starts(start_time=1421176750.514707, stop_time=time.time()})
-    >>> find_run_starts(start_time=1421176750.514707, stop_time=time.time())
+    >>> find_run_starts(since=1421176750.514707, until=time.time()})
+    >>> find_run_starts(since=1421176750.514707, until=time.time())
 
-    >>> find_run_starts(owner='arkilic', start_time=1421176750.514707,
-    ...                stop_time=time.time())
+    >>> find_run_starts(owner='arkilic', since=1421176750.514707,
+    ...                until=time.time())
 
     """
     # now try rest of formatting
@@ -837,7 +837,7 @@ def find_run_stops(stop_col, stop_cache, tz,
     ----------
     run_start : dict or str, optional
         The RunStart document or uid to get the corresponding run end for
-    start_time : time-like, optional
+    since : time-like, optional
         time-like representation of the earliest time that a RunStop
         was created. Valid options are:
            - timestamps --> time.time()
@@ -846,9 +846,9 @@ def find_run_stops(stop_col, stop_cache, tz,
            - '2015-01-30'
            - '2015-03-30 03:00:00'
            - datetime.datetime.now()
-    stop_time : time-like, optional
+    until : time-like, optional
         timestamp of the latest time that a RunStop was created. See
-        docs for `start_time` for examples.
+        docs for `since` for examples.
     exit_status : {'success', 'fail', 'abort'}, optional
         provides information regarding the run success.
     reason : str, optional
@@ -884,7 +884,7 @@ def find_descriptors(descriptor_col, descriptor_cache,
     ----------
     run_start : dict or str, optional
         The RunStart document or uid to get the corresponding run end for
-    start_time : time-like, optional
+    since : time-like, optional
         time-like representation of the earliest time that an EventDescriptor
         was created. Valid options are:
            - timestamps --> time.time()
@@ -893,9 +893,9 @@ def find_descriptors(descriptor_col, descriptor_cache,
            - '2015-01-30'
            - '2015-03-30 03:00:00'
            - datetime.datetime.now()
-    stop_time : time-like, optional
+    until : time-like, optional
         timestamp of the latest time that an EventDescriptor was created. See
-        docs for `start_time` for examples.
+        docs for `since` for examples.
     uid : str, optional
         Globally unique id string provided to metadatastore
 

--- a/databroker/headersource/mongo.py
+++ b/databroker/headersource/mongo.py
@@ -155,7 +155,7 @@ class MDSRO(MDSROTemplate):
 
         Parameters
         -----------
-        start_time : time-like, optional
+        since : time-like, optional
             time-like representation of the earliest time that an Event
             was created. Valid options are:
                - timestamps --> time.time()
@@ -164,9 +164,9 @@ class MDSRO(MDSROTemplate):
                - '2015-01-30'
                - '2015-03-30 03:00:00'
                - datetime.datetime.now()
-        stop_time : time-like, optional
+        until : time-like, optional
             timestamp of the latest time that an Event was created. See
-            docs for `start_time` for examples.
+            docs for `since` for examples.
         descriptor : doc.Document or str, optional
            Find events for a given EventDescriptor
         uid : str, optional

--- a/databroker/headersource/mongo_core.py
+++ b/databroker/headersource/mongo_core.py
@@ -133,7 +133,7 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
 
     Parameters
     ----------
-    start_time : time-like, optional
+    since : time-like, optional
         time-like representation of the earliest time that a RunStart
         was created. Valid options are:
            - timestamps --> time.time()
@@ -142,9 +142,9 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
            - '2015-01-30'
            - '2015-03-30 03:00:00'
            - datetime.datetime.now()
-    stop_time : time-like, optional
+    until : time-like, optional
         timestamp of the latest time that a RunStart was created. See
-        docs for `start_time` for examples.
+        docs for `since` for examples.
     beamline_id : str, optional
         String identifier for a specific beamline
     project : str, optional
@@ -163,11 +163,11 @@ def find_run_starts(run_start_col, run_start_cache, tz, **kwargs):
     --------
     >>> find_run_starts(scan_id=123)
     >>> find_run_starts(owner='arkilic')
-    >>> find_run_starts(start_time=1421176750.514707, stop_time=time.time()})
-    >>> find_run_starts(start_time=1421176750.514707, stop_time=time.time())
+    >>> find_run_starts(since=1421176750.514707, until=time.time()})
+    >>> find_run_starts(since=1421176750.514707, until=time.time())
 
-    >>> find_run_starts(owner='arkilic', start_time=1421176750.514707,
-    ...                stop_time=time.time())
+    >>> find_run_starts(owner='arkilic', since=1421176750.514707,
+    ...                until=time.time())
 
     """
     # now try rest of formatting
@@ -187,7 +187,7 @@ def find_run_stops(stop_col, stop_cache, tz,
     ----------
     run_start : dict or str, optional
         The RunStart document or uid to get the corresponding run end for
-    start_time : time-like, optional
+    since : time-like, optional
         time-like representation of the earliest time that a RunStop
         was created. Valid options are:
            - timestamps --> time.time()
@@ -196,9 +196,9 @@ def find_run_stops(stop_col, stop_cache, tz,
            - '2015-01-30'
            - '2015-03-30 03:00:00'
            - datetime.datetime.now()
-    stop_time : time-like, optional
+    until : time-like, optional
         timestamp of the latest time that a RunStop was created. See
-        docs for `start_time` for examples.
+        docs for `since` for examples.
     exit_status : {'success', 'fail', 'abort'}, optional
         provides information regarding the run success.
     reason : str, optional
@@ -234,7 +234,7 @@ def find_descriptors(descriptor_col, descriptor_cache,
     ----------
     run_start : dict or str, optional
         The RunStart document or uid to get the corresponding run end for
-    start_time : time-like, optional
+    since : time-like, optional
         time-like representation of the earliest time that an EventDescriptor
         was created. Valid options are:
            - timestamps --> time.time()
@@ -243,9 +243,9 @@ def find_descriptors(descriptor_col, descriptor_cache,
            - '2015-01-30'
            - '2015-03-30 03:00:00'
            - datetime.datetime.now()
-    stop_time : time-like, optional
+    until : time-like, optional
         timestamp of the latest time that an EventDescriptor was created. See
-        docs for `start_time` for examples.
+        docs for `since` for examples.
     uid : str, optional
         Globally unique id string provided to metadatastore
 
@@ -276,7 +276,7 @@ def find_events(start_col, start_cache,
 
     Parameters
     -----------
-    start_time : time-like, optional
+    since : time-like, optional
         time-like representation of the earliest time that an Event
         was created. Valid options are:
            - timestamps --> time.time()
@@ -285,9 +285,9 @@ def find_events(start_col, start_cache,
            - '2015-01-30'
            - '2015-03-30 03:00:00'
            - datetime.datetime.now()
-    stop_time : time-like, optional
+    until : time-like, optional
         timestamp of the latest time that an Event was created. See
-        docs for `start_time` for examples.
+        docs for `since` for examples.
     descriptor : dict or str, optional
        Find events for a given EventDescriptor
     uid : str, optional

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -273,7 +273,7 @@ def test_find_by_float_time(db_empty, RE, hw):
     assert len(list(db())) == 3
 
     # We'll find the one by specifying a time window around its start time.
-    header, = db(start_time=t - 0.1, stop_time=t + 0.2)
+    header, = db(since=t - 0.1, until=t + 0.2)
     assert header['start']['uid'] == during
 
 
@@ -289,9 +289,9 @@ def test_find_by_string_time(db_empty, RE, hw):
     tomorrow_str = tomorrow.strftime('%Y-%m-%d')
     day_after_tom = date.today() + timedelta(days=2)
     day_after_tom_str = day_after_tom.strftime('%Y-%m-%d')
-    assert len(list(db(start_time=today_str, stop_time=tomorrow_str))) == 1
-    assert len(list(db(start_time=tomorrow_str,
-                       stop_time=day_after_tom_str))) == 0
+    assert len(list(db(since=today_str, until=tomorrow_str))) == 1
+    assert len(list(db(since=tomorrow_str,
+                       until=day_after_tom_str))) == 0
 
 
 @py3
@@ -382,15 +382,15 @@ def test_filters(db_empty, RE, hw):
     assert header['start']['uid'] == ken_calib_uid
 
     db.clear_filters()
-    db.add_filter(start_time='2017')
-    db.add_filter(start_time='2017')
+    db.add_filter(since='2017')
+    db.add_filter(since='2017')
     assert len(db.filters) == 1
-    db.add_filter(start_time='2016', stop_time='2017')
+    db.add_filter(since='2016', until='2017')
     assert len(db.filters) == 2
-    assert db.filters['start_time'] == '2016'
+    assert db.filters['since'] == '2016'
 
     db()  # after search, time content keeps the same
-    assert db.filters['start_time'] == '2016'
+    assert db.filters['since'] == '2016'
 
 
 @py3

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -276,6 +276,11 @@ def test_find_by_float_time(db_empty, RE, hw):
     header, = db(since=t - 0.1, until=t + 0.2)
     assert header['start']['uid'] == during
 
+    # Test the old names
+    with pytest.warns(UserWarning):
+        header, = db(start_time=t - 0.1, stop_time=t + 0.2)
+    assert header['start']['uid'] == during
+
 
 @py3
 def test_find_by_string_time(db_empty, RE, hw):
@@ -389,9 +394,19 @@ def test_filters(db_empty, RE, hw):
     assert len(db.filters) == 2
     assert db.filters['since'] == '2016'
 
-    db()  # after search, time content keeps the same
+    list(db())  # after search, time content keeps the same
     assert db.filters['since'] == '2016'
 
+    # Check again using old names (start_time, stop_time)
+    db.clear_filters()
+    db.add_filter(start_time='2017')
+    db.add_filter(start_time='2017')
+    assert len(db.filters) == 1
+    db.add_filter(start_time='2016', stop_time='2017')
+    assert len(db.filters) == 2
+    assert db.filters['start_time'] == '2016'
+    with pytest.warns(UserWarning):
+        list(db())
 
 @py3
 @pytest.mark.parametrize(

--- a/databroker/utils.py
+++ b/databroker/utils.py
@@ -51,11 +51,11 @@ def format_time(search_dict, tz):
     """
     # The old names of 'since' and 'until' are 'start_time' and 'stop_time'.
     if 'since' in search_dict and 'start_time' in search_dict:
-        raise ValueError("cannot use both 'since' and its deprecated name "
-                         "'start_time'")
+        raise TypeError("cannot use both 'since' and its deprecated name "
+                        "'start_time'")
     if 'until' in search_dict and 'stop_time' in search_dict:
-        raise ValueError("cannot use both 'until' and its deprecated name "
-                         "'stop_time'")
+        raise TypeError("cannot use both 'until' and its deprecated name "
+                        "'stop_time'")
     if 'start_time' in search_dict or 'stop_time' in search_dict:
         warnings.warn("The keyword 'start_time' and 'stop_time' have been "
                       "renamed to 'since' and 'until'. The old names are "

--- a/databroker/utils.py
+++ b/databroker/utils.py
@@ -3,6 +3,7 @@ import numpy as np
 import os
 import pytz
 import six
+import warnings
 
 
 class ALL:
@@ -48,9 +49,20 @@ def format_time(search_dict, tz):
 
     ..warning: Does in-place mutation of the search_dict
     """
+    # The old names of 'since' and 'until' are 'start_time' and 'stop_time'.
+    if 'since' in search_dict and 'start_time' in search_dict:
+        raise ValueError("cannot use both 'since' and its deprecated name "
+                         "'start_time'")
+    if 'until' in search_dict and 'stop_time' in search_dict:
+        raise ValueError("cannot use both 'until' and its deprecated name "
+                         "'stop_time'")
+    if 'start_time' in search_dict or 'stop_time' in search_dict:
+        warnings.warn("The keyword 'start_time' and 'stop_time' have been "
+                      "renamed to 'since' and 'until'. The old names are "
+                      "deprecated.")
     time_dict = {}
-    since = search_dict.pop('since', None)
-    until = search_dict.pop('until', None)
+    since = search_dict.pop('since', search_dict.pop('start_time', None))
+    until = search_dict.pop('until', search_dict.pop('stop_time', None))
     if since:
         time_dict['$gte'] = normalize_human_friendly_time(since, tz)
     if until:

--- a/databroker/utils.py
+++ b/databroker/utils.py
@@ -44,17 +44,17 @@ def apply_to_dict_recursively(d, f):
 def format_time(search_dict, tz):
     """Helper function to format the time arguments in a search dict
 
-    Expects 'start_time' and 'stop_time'
+    Expects 'since' and 'until'
 
     ..warning: Does in-place mutation of the search_dict
     """
     time_dict = {}
-    start_time = search_dict.pop('start_time', None)
-    stop_time = search_dict.pop('stop_time', None)
-    if start_time:
-        time_dict['$gte'] = normalize_human_friendly_time(start_time, tz)
-    if stop_time:
-        time_dict['$lte'] = normalize_human_friendly_time(stop_time, tz)
+    since = search_dict.pop('since', None)
+    until = search_dict.pop('until', None)
+    if since:
+        time_dict['$gte'] = normalize_human_friendly_time(since, tz)
+    if until:
+        time_dict['$lte'] = normalize_human_friendly_time(until, tz)
     if time_dict:
         search_dict['time'] = time_dict
 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -203,7 +203,7 @@ Any user-provided metadata can be used in a search. Examples:
     headers = db(operator='Dan')
 
     # Search by time range. (These keywords have a special meaning.)
-    headers = db(start_time='2015-03-05', stop_time='2015-03-10')
+    headers = db(since='2015-03-05', until='2015-03-10')
 
 Full-text search is also supported, for MongoDB-backed deployments. (Other
 deploymeents will raise :class:`NotImplementedError` if you try this.)

--- a/doc/source/whats_new.rst
+++ b/doc/source/whats_new.rst
@@ -7,6 +7,7 @@ A catalog of new features, improvements, and bug-fixes in each release. Follow
 links to the relevant GitHub issue or pull request for specific code changes
 and any related discussion.
 
+.. include:: whats_new/v0.10.0.txt
 .. include:: whats_new/v0.9.4.txt
 .. include:: whats_new/v0.9.3.txt
 .. include:: whats_new/v0.9.2.txt

--- a/doc/source/whats_new/v0.10.0.txt
+++ b/doc/source/whats_new/v0.10.0.txt
@@ -1,0 +1,28 @@
+.. currentmodule:: databroker
+
+v0.10.0
+-------
+
+Enhancements
+++++++++++++
+
+* Add special name ``Broker.named('temp')`` which creates new, temporary
+  storage each time it is called. This is convenient for testing and teaching.
+
+Deprecations
+++++++++++++
+
+* The :meth:`Broker.__call__` method for searching headers by metadata accepted
+  special keyword arguments, ``start_time`` and/or ``end_time``, which filtered
+  results by RunStart time. These names proved to be confusing, so they have
+  been renamed ``since`` and ``until`` (terminology inspired by ``git log``).
+  The original names still work, but warn if used.
+
+Bug Fixes
++++++++++
+
+* The mongoquery backend returned identical references (i.e. the same
+  dictionary) on subsequent queries, meaning that mutations could propagate
+  across results sets.
+* Ensure there is only one definition of a ``DuplicateHandler`` exception.
+* Remove invalid keyword argument from ``get_images``.


### PR DESCRIPTION
These names of confusing, especially 'end_time' because people think
it filters on the time that a run ends. The names 'since' and 'until'
come from `git log`.

Closes #320

I also found some code that should have been deleted in the
"octomerge".