### PR TITLE
Revert "Refactor HDF5 handlers and add DASK handler"

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -483,19 +483,12 @@ def register_builtin_handlers(reg):
     from .assets import handlers
     # TODO This will blow up if any non-leaves in the class heirarchy
     # have non-empty specs. Make this smart later.
-
     for cls in vars(handlers).values():
         if isinstance(cls, type) and issubclass(cls, handlers.HandlerBase):
             logger.debug("Found Handler %r for specs %r", cls, cls.specs)
-            if getattr(cls, 'autoregister', False):
-                for spec in cls.specs:
-                    logger.debug("Registering Handler %r for spec %r", cls,
-                                 spec)
-                    reg.register_handler(spec, cls)
-            else:
-                logger.debug("NOT Registering Handler %r for specs %r", cls,
-                             cls.specs)
-
+            for spec in cls.specs:
+                logger.debug("Registering Handler %r for spec %r", cls, spec)
+                reg.register_handler(spec, cls)
 
 def get_fields(header, name=None):
     """

--- a/databroker/assets/handlers_base.py
+++ b/databroker/assets/handlers_base.py
@@ -12,7 +12,6 @@ class HandlerBase(object):
     ``__enter__``, ``__exit__`` and ``close``
     """
     specs = set()
-    autoregister = False
 
     def __enter__(self):
         return self

--- a/databroker/assets/tests/test_handlers.py
+++ b/databroker/assets/tests/test_handlers.py
@@ -10,10 +10,8 @@ import tifffile
 
 from ..handlers import AreaDetectorHDF5Handler
 from ..handlers import AreaDetectorHDF5SWMRHandler
-from ..handlers import AreaDetectorHDF5DaskHandler
 from ..handlers import AreaDetectorHDF5TimestampHandler
 from ..handlers import AreaDetectorHDF5SWMRTimestampHandler
-from ..handlers import AreaDetectorHDF5PyHandler
 from ..handlers import AreaDetectorTiffHandler
 from ..handlers import DummyAreaDetectorHandler
 from ..handlers import HDFMapsSpectrumHandler as HDFM
@@ -39,18 +37,12 @@ def fs_with_handlers(request, fs_cls):
     fs.register_handler('AD_HDF5_TS', AreaDetectorHDF5TimestampHandler)
     fs.register_handler('AD_HDF5_SWMR_TS',
                         AreaDetectorHDF5SWMRTimestampHandler)
-    fs.register_handler('AD_HDF5_DASK',
-                        AreaDetectorHDF5DaskHandler)
-    fs.register_handler('AD_HDF5_PY',
-                        AreaDetectorHDF5PyHandler)
 
     def deregister_handlers():
         fs.deregister_handler('AD_HDF5')
         fs.deregister_handler('AD_HDF5_SWMR')
         fs.deregister_handler('AD_HDF5_TS')
         fs.deregister_handler('AD_HDF5_SWMR_TS')
-        fs.deregister_handler('AD_HDF5_DASK')
-        fs.deregister_handler('AD_HDF5_PY')
 
     request.addfinalizer(deregister_handlers)
     request.cls.fs = fs
@@ -169,16 +161,6 @@ class Test_AD_hdf5_files(_with_file):
         assert hand._file is not None
         hand.close()
         assert hand._file is None
-
-
-class Test_AD_hdf5_dask_files(_with_file):
-    spec = 'AD_HDF5_DASK'
-    handler = AreaDetectorHDF5DaskHandler
-
-
-class Test_AD_hdf5_py_files(_with_file):
-    spec = 'AD_HDF5_PY'
-    handler = AreaDetectorHDF5PyHandler
 
 
 # class Test_AD_hdf5_SWMR_files(Test_AD_hdf5_files):


### PR DESCRIPTION
Reverts NSLS-II/databroker#308

This breaks sub-classes which passing in 'key' as a string (as is still documented).