### PR TITLE
Add get_config

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -2193,6 +2193,17 @@ class Broker(BrokerES):
         db = cls.from_config(config, auto_register=auto_register)
         return db
 
+    def get_config(self):
+        ''' Get the config for this Broker.
+            To be used by Broker.from_config(config)
+        '''
+        config = dict()
+        config['metadatastore'] = self.mds.config
+        config['assets'] = self.reg.config
+        config['root_map'] = self.reg.root_map
+        return config
+
+
 
 def _sanitize(doc):
     # Make this a plain dict and strip off doct.Document artifacts.

--- a/databroker/tests/test_config.py
+++ b/databroker/tests/test_config.py
@@ -58,13 +58,9 @@ def test_from_config():
     reg_config = config['assets']
     root_map_config = config['root_map']
 
-    for key, val in mds_config.items():
-        assert mds_example[key] == val
-    for key, val in reg_config.items():
-        assert reg_example[key] == val
-    for key, val in root_map_config.items():
-        assert root_map_example[key] == val
-
+    assert mds_example == mds_config
+    assert reg_example == reg_config
+    assert root_map_example == root_map_config
 
 
 def test_handler_registration():

--- a/databroker/tests/test_config.py
+++ b/databroker/tests/test_config.py
@@ -46,7 +46,25 @@ EXAMPLE = {
 
 
 def test_from_config():
-    Broker.from_config(EXAMPLE)
+    broker = Broker.from_config(EXAMPLE)
+    config = broker.get_config()
+    print(config)
+    # we explicitly test for parts we know should be accepted
+    mds_example = EXAMPLE['metadatastore']['config']
+    reg_example = EXAMPLE['assets']['config']
+    root_map_example = EXAMPLE['root_map']
+
+    mds_config = config['metadatastore']
+    reg_config = config['assets']
+    root_map_config = config['root_map']
+
+    for key, val in mds_config.items():
+        assert mds_example[key] == val
+    for key, val in reg_config.items():
+        assert reg_example[key] == val
+    for key, val in root_map_config.items():
+        assert root_map_example[key] == val
+
 
 
 def test_handler_registration():


### PR DESCRIPTION
before i forget, i think this may be useful.
@danielballan and I discussed this.

If we want to pass minimal information about the databroker connection between processes, this could be useful. Still need to discuss serialization of headers with @tacaswell 

PS : this is not very clean. If we were to add more features to the config file, we need to remember to modify `get_config` and the test. If anyone has suggestions id like to hear