### PR TITLE
DOC: Fix formatting; add section titles; add more description.

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -64,8 +64,17 @@ This requires more work to set up.
             port: 27017
             database: 'some_example_database'
 
+In these examples, the classes used happen to be from the ``databroker``
+package itself, but classes from other packages can be used just as well, as
+long as they present the expected API. (This API is not yet documented outside
+of the source code.)
+
+Registering Handlers
+--------------------
+
 Configuration files may optionally include a section specifying 'handlers',
-classes that load externally stored data.
+classes that load externally stored data. These may be registered at runtime or
+here in configuration. See :doc:`assets` for more on handlers.
 
 .. code-block:: yaml
 
@@ -74,20 +83,20 @@ classes that load externally stored data.
             module: 'databroker.assets.path_only_handlers'
             class: 'RawHandler'
 
+Coping with Moved Files or Different Mount Points
+-------------------------------------------------
+
 Optionally, you may set a root_map, which comes in handy when the handlers
 involves mounted files that have been moved to a different mount point in the
 file system.
+
 .. code-block:: yaml
+
     root_map : {'old_root': 'new_root',
                 'old_root2' : 'new_root2',}
 
 where ``old_root`` and ``old_root2`` are the old mount points and ``new_root``
 and ``new_root2`` their respective new mount points.
-
-In these examples, the classes used happen to be from the ``databroker``
-package itself, but classes from other packages can be used just as well, as
-long as they present the expected API. (This API is not yet documented outside
-of the source code.)
 
 .. warning::
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -92,8 +92,9 @@ file system.
 
 .. code-block:: yaml
 
-    root_map : {'old_root': 'new_root',
-                'old_root2' : 'new_root2',}
+    root_map:
+        old_root: new_root
+        old_root2: new_root2
 
 where ``old_root`` and ``old_root2`` are the old mount points and ``new_root``
 and ``new_root2`` their respective new mount points.


### PR DESCRIPTION
- code-block needs a blank line before the code begins or it does
  not render as code
- I added some new section headings to make it easier to quickly find things.
- I moved a paragraph that had gotten pushed too far down the page.
- I added some explanation around handlers, with a link to the new assets
  section.