### PR TITLE
Add stream_name option to fields

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -188,7 +188,8 @@ class Header(object):
         """
         fields = set()
         for es in self.db.event_sources:
-            fields.update(es.fields_given_header(header=self))
+            fields.update(es.fields_given_header(header=self,
+                                                 stream_name=stream_name))
         return fields
 
     def devices(self, stream_name=ALL):

--- a/databroker/eventsource/shim.py
+++ b/databroker/eventsource/shim.py
@@ -39,9 +39,9 @@ class EventSourceShim(object):
         return set(d.get('name', 'primary') for d in
                    self.descriptors_given_header(header))
 
-    def fields_given_header(self, header):
+    def fields_given_header(self, header, stream_name=ALL):
         fields = set()
-        for d in self.descriptors_given_header(header):
+        for d in self.descriptors_given_header(header, stream_name=stream_name):
             fields.update(d['data_keys'])
         return fields
 

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -514,7 +514,6 @@ def test_stream_name(db, RE, hw):
     # subscribe db.insert
     RE.subscribe(db.insert)
 
-
     # custom plan that will generate two streams
     @run_decorator()
     def myplan(dets):
@@ -522,9 +521,10 @@ def test_stream_name(db, RE, hw):
 
         Meant for test only.
         '''
-        yield trigger_and_read([dets[0]], name='primary')
-        yield trigger_and_read([dets[1]], name='secondary')
-
+        for msg in trigger_and_read([dets[0]], name='primary'):
+            yield msg
+        for msg in trigger_and_read([dets[1]], name='secondary'):
+            yield msg
 
     # this test is meaningless (will always pass)
     # if our two detectors have the same name. Ensure this is true

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -546,11 +546,13 @@ def test_stream_name(db, RE, hw):
 
     db.mds.insert_event(descriptor=desc_uid2, time=ttime.time(), uid=event_uid2,
                         data={'image2': datum_id2},
-                        timestamps={'image': ttime.time()}, seq_num=0)
+                        timestamps={'image2': ttime.time()}, seq_num=0)
 
     h = db[rs_uid]
 
-    assert h.fields() == {'image', 'image2'}
+    assert h.fields() == {'image', 'image2', 'det'}
+    assert h.fields(stream_name='primary') == {'det'}
+    assert h.fields(stream_name='injected') == {'image'}
     assert h.fields(stream_name='injected2') == {'image2'}
 
 

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -510,6 +510,51 @@ def test_configuration(db, RE):
 
 
 @py3
+def test_stream_name(db, RE, hw):
+    datum_id = str(uuid.uuid4())
+    datum_id2 = str(uuid.uuid4())
+    desc_uid = str(uuid.uuid4())
+    desc_uid2 = str(uuid.uuid4())
+    event_uid = str(uuid.uuid4())
+    event_uid2 = str(uuid.uuid4())
+
+    # Side-band resource and datum documents.
+    res = db.reg.insert_resource('foo', '', {'x': 1})
+    db.reg.insert_datum(res, datum_id, {'y': 2})
+
+    res2 = db.reg.insert_resource('foo', '', {'x': 1})
+    db.reg.insert_datum(res2, datum_id2, {'y': 2})
+
+    # Generate a normal run.
+    RE.subscribe(db.insert)
+    rs_uid, = RE(count([hw.det]))
+
+    # Side band an extra descriptor and event into this run.
+    data_keys = {'image': {'dtype': 'array', 'source': '', 'shape': [5, 5],
+                           'external': 'FILESTORE://simulated'}}
+    data_keys2 = {'image2': {'dtype': 'array', 'source': '', 'shape': [5, 5],
+                           'external': 'FILESTORE://simulated'}}
+    db.mds.insert_descriptor(run_start=rs_uid, data_keys=data_keys,
+                             time=ttime.time(), uid=desc_uid,
+                             name='injected')
+    db.mds.insert_descriptor(run_start=rs_uid, data_keys=data_keys2,
+                             time=ttime.time(), uid=desc_uid2,
+                             name='injected2')
+    db.mds.insert_event(descriptor=desc_uid, time=ttime.time(), uid=event_uid,
+                        data={'image': datum_id},
+                        timestamps={'image': ttime.time()}, seq_num=0)
+
+    db.mds.insert_event(descriptor=desc_uid2, time=ttime.time(), uid=event_uid2,
+                        data={'image2': datum_id2},
+                        timestamps={'image': ttime.time()}, seq_num=0)
+
+    h = db[rs_uid]
+
+    assert h.fields() == {'image', 'image2'}
+    assert h.fields(stream_name='injected2') == {'image2'}
+
+
+@py3
 def test_handler_options(db, RE, hw):
     datum_id = str(uuid.uuid4())
     datum_id2 = str(uuid.uuid4())

--- a/databroker/tests/test_broker.py
+++ b/databroker/tests/test_broker.py
@@ -522,8 +522,8 @@ def test_stream_name(db, RE, hw):
 
         Meant for test only.
         '''
-        yield from trigger_and_read([dets[0]], name='primary')
-        yield from trigger_and_read([dets[1]], name='secondary')
+        yield trigger_and_read([dets[0]], name='primary')
+        yield trigger_and_read([dets[1]], name='secondary')
 
 
     # this test is meaningless (will always pass)


### PR DESCRIPTION
This looks like it's missing (currently trying to read fields only for a certain stream).
tested locally at QAS, still needs test.