### PR TITLE
ENH: Implement Broker.insert for 'datum' and 'resource'

### DIFF
--- a/databroker/assets/base_registry.py
+++ b/databroker/assets/base_registry.py
@@ -569,7 +569,7 @@ class RegistryTemplate(BaseRegistryRO):
 
     # ## OLD API
     def insert_resource(self, spec, resource_path, resource_kwargs, root=None,
-                        path_semantics='posix', uid=None,
+                        path_semantics='posix', uid=None, run_start=None,
                         ignore_duplicate_error=False):
         '''
 
@@ -586,6 +586,7 @@ class RegistryTemplate(BaseRegistryRO):
             root=root,
             path_semantics=path_semantics,
             uid=uid,
+            run_start=run_start,
             ignore_duplicate_error=ignore_duplicate_error,
             duplicate_exc=self.DuplicateKeyError)
 

--- a/databroker/assets/base_registry.py
+++ b/databroker/assets/base_registry.py
@@ -568,7 +568,9 @@ class RegistryTemplate(BaseRegistryRO):
         pass
 
     # ## OLD API
-    def insert_resource(self, spec, resource_path, resource_kwargs, root=None):
+    def insert_resource(self, spec, resource_path, resource_kwargs, root=None,
+                        path_semantics='posix', uid=None,
+                        ignore_duplicate_error=False):
         '''
 
         '''
@@ -577,12 +579,18 @@ class RegistryTemplate(BaseRegistryRO):
 
         col = self._resource_col
 
-        return self._api.insert_resource(col, spec, resource_path,
-                                         resource_kwargs,
-                                         self.known_spec,
-                                         root=root)
+        return self._api.insert_resource(
+            col, spec, resource_path,
+            resource_kwargs,
+            self.known_spec,
+            root=root,
+            path_semantics=path_semantics,
+            uid=uid,
+            ignore_duplicate_error=ignore_duplicate_error,
+            duplicate_exc=self.DuplicateKeyError)
 
-    def insert_datum(self, resource, datum_id, datum_kwargs):
+    def insert_datum(self, resource, datum_id, datum_kwargs,
+                     ignore_duplicate_error=False):
         '''insert a datum for the given resource
 
         Parameters
@@ -603,8 +611,11 @@ class RegistryTemplate(BaseRegistryRO):
         '''
         col = self._datum_col
 
-        return self._api.insert_datum(col, resource, datum_id, datum_kwargs,
-                                      self.known_spec, self._resource_col)
+        return self._api.insert_datum(
+            col, resource, datum_id, datum_kwargs,
+            self.known_spec, self._resource_col,
+            ignore_duplicate_error=ignore_duplicate_error,
+            duplicate_exc=self.DuplicateKeyError)
 
     def bulk_insert_datum(self, resource, datum_ids, datum_kwarg_list):
         col = self._datum_col

--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -162,6 +162,7 @@ def insert_datum(col, resource, datum_id, datum_kwargs, known_spec,
 
 def insert_resource(col, spec, resource_path, resource_kwargs,
                     known_spec, root, path_semantics='posix', uid=None,
+                    run_start=None,
                     ignore_duplicate_error=False, duplicate_exc=None):
     if ignore_duplicate_error:
         assert duplicate_exc is not None
@@ -177,6 +178,10 @@ def insert_resource(col, spec, resource_path, resource_kwargs,
                            resource_kwargs=resource_kwargs,
                            path_semantics=path_semantics,
                            uid=uid)
+    # This is special-cased because it was added later.
+    # Someday this may be required and no longer special-cased.
+    if run_start is not None:
+        resource_object['run_start'] = run_start
     # We are transitioning from ophyd objects inserting directly into a
     # Registry to ophyd objects passing documents to the RunEngine which in
     # turn inserts them into a Registry. During the transition period, we allow

--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -117,7 +117,10 @@ def register_datum(col, resource_uid, datum_kwargs):
 
 
 def insert_datum(col, resource, datum_id, datum_kwargs, known_spec,
-                 resource_col):
+                 resource_col, ignore_duplicate_error=False,
+                 duplicate_exc=None):
+    if ignore_duplicate_error:
+        assert duplicate_exc is not None
     try:
         resource['spec']
         spec = resource['spec']
@@ -133,7 +136,19 @@ def insert_datum(col, resource, datum_id, datum_kwargs, known_spec,
                  datum_id=str(datum_id),
                  datum_kwargs=dict(datum_kwargs))
     apply_to_dict_recursively(datum, sanitize_np)
-    col.insert_one(datum)
+    # We are transitioning from ophyd objects inserting directly into a
+    # Registry to ophyd objects passing documents to the RunEngine which in
+    # turn inserts them into a Registry. During the transition period, we allow
+    # an ophyd object to attempt BOTH so that configuration files are
+    # compatible with both the new model and the old model. Thus, we need to
+    # ignore the second attempt to insert.
+    try:
+        col.insert_one(datum)
+    except duplicate_exc:
+        if ignore_duplicate_error:
+            pass
+        else:
+            raise
     # do not leak mongo objectID
     datum.pop('_id', None)
 
@@ -141,20 +156,35 @@ def insert_datum(col, resource, datum_id, datum_kwargs, known_spec,
 
 
 def insert_resource(col, spec, resource_path, resource_kwargs,
-                    known_spec, root, path_semantics='posix'):
+                    known_spec, root, path_semantics='posix', uid=None,
+                    ignore_duplicate_error=False, duplicate_exc=None):
+    if ignore_duplicate_error:
+        assert duplicate_exc is not None
     resource_kwargs = dict(resource_kwargs)
     if spec in known_spec:
         js_validate(resource_kwargs, known_spec[spec]['resource'])
+    if uid is None:
+        uid = str(uuid.uuid4())
 
     resource_object = dict(spec=str(spec),
                            resource_path=str(resource_path),
                            root=str(root),
                            resource_kwargs=resource_kwargs,
                            path_semantics=path_semantics,
-                           uid=str(uuid.uuid4()))
-
-    col.insert_one(resource_object)
-    # maintain back compatibility
+                           uid=uid)
+    # We are transitioning from ophyd objects inserting directly into a
+    # Registry to ophyd objects passing documents to the RunEngine which in
+    # turn inserts them into a Registry. During the transition period, we allow
+    # an ophyd object to attempt BOTH so that configuration files are
+    # compatible with both the new model and the old model. Thus, we need to
+    # ignore the second attempt to insert.
+    try:
+        col.insert_one(resource_object)
+    except duplicate_exc:
+        if ignore_duplicate_error:
+            pass
+        else:
+            raise
     resource_object['id'] = resource_object['uid']
     resource_object.pop('_id', None)
     return resource_object

--- a/databroker/assets/core.py
+++ b/databroker/assets/core.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 from jsonschema import validate as js_validate
+import warnings
 import uuid
 import time as ttime
 import pandas as pd
@@ -146,7 +147,11 @@ def insert_datum(col, resource, datum_id, datum_kwargs, known_spec,
         col.insert_one(datum)
     except duplicate_exc:
         if ignore_duplicate_error:
-            pass
+            warnings.warn("Ignoring attempt to insert Resource with duplicate "
+                          "uid, assuming that both ophyd and bluesky "
+                          "attempted to insert this document. Remove the "
+                          "Registry (`reg` parameter) from your ophyd "
+                          "instance to remove this warning.")
         else:
             raise
     # do not leak mongo objectID
@@ -182,7 +187,11 @@ def insert_resource(col, spec, resource_path, resource_kwargs,
         col.insert_one(resource_object)
     except duplicate_exc:
         if ignore_duplicate_error:
-            pass
+            warnings.warn("Ignoring attempt to insert Datum with duplicate "
+                          "datum_id, assuming that both ophyd and bluesky "
+                          "attempted to insert this document. Remove the "
+                          "Registry (`reg` parameter) from your ophyd "
+                          "instance to remove this warning.")
         else:
             raise
     resource_object['id'] = resource_object['uid']

--- a/databroker/assets/file_writers.py
+++ b/databroker/assets/file_writers.py
@@ -86,15 +86,14 @@ class NpyWriter(HandlerBase):
             raise IOError("the requested file {fpath} "
                           "already exist".format(fpath=self._fpath))
 
-        if uid is None:
-            uid = str(uuid.uuid1())
-
         np.save(self._fpath, np.asanyarray(data))
         self._writable = False
         fb = self.fs.insert_resource(self.SPEC_NAME,
                                      self._fpath,
                                      self._f_custom,
                                      root='/')
+        if uid is None:
+            uid = fb['uid'] + '/0'
         evl = self.fs.insert_datum(fb, uid, {})
 
         return evl['datum_id']

--- a/databroker/assets/tests/test_fs.py
+++ b/databroker/assets/tests/test_fs.py
@@ -31,7 +31,7 @@ def test_non_exist(fs):
 def test_root(fs):
     print(fs._db)
     res = fs.insert_resource('root-test', 'foo', {}, root='bar')
-    dm = fs.insert_datum(res, str(uuid.uuid4()), {})
+    dm = fs.insert_datum(res, res['uid'] + '/0', {})
     if fs.version == 1:
         assert res['root'] == 'bar'
 

--- a/databroker/assets/tests/test_fs_mutate.py
+++ b/databroker/assets/tests/test_fs_mutate.py
@@ -150,7 +150,7 @@ def moving_files(request, fs_v1, tmpdir):
         fpath = os.path.join(tmpdir, local_path,
                              fmt.format(point_number=j))
         np.save(fpath, np.ones(shape) * j)
-        d = fs_v1.insert_datum(res, str(uuid.uuid4()),
+        d = fs_v1.insert_datum(res, '{}/{}'.format(res['uid'], j),
                                {'point_number': j})
         datum_ids.append(d['datum_id'])
         fnames.append(fpath)
@@ -219,7 +219,7 @@ def test_temporary_root(fs_v1):
     print(fs.root_map)
     print(fs._handler_cache)
     res = fs.insert_resource('root-test', 'foo', {}, root='bar')
-    dm = fs.insert_datum(res, str(uuid.uuid4()), {})
+    dm = fs.insert_datum(res, res['uid'] + '/0', {})
     if fs.version == 1:
         assert res['root'] == 'bar'
 
@@ -236,7 +236,7 @@ def test_temporary_root(fs_v1):
 
     # test two root maps work
     res = fs.insert_resource('root-test', 'foo', {}, root='bar2')
-    dm = fs.insert_datum(res, str(uuid.uuid4()), {})
+    dm = fs.insert_datum(res, res['uid'] + '/0', {})
     if fs.version == 1:
         assert res['root'] == 'bar2'
 

--- a/databroker/assets/tests/utils.py
+++ b/databroker/assets/tests/utils.py
@@ -54,7 +54,7 @@ def insert_syn_data_with_resource(fs, f_type, shape, count):
                                      lambda x: x['id'],
                                      lambda x: str(x['id'])))
     for k, rmap in zip(range(count), res_map_cycle):
-        r_id = str(uuid.uuid4())
+        r_id = '{}/{}'.format(fb['uid'], k)
         datum = fs.insert_datum(rmap(fb), r_id, {'n': k + 1})
         ret.append(datum['datum_id'])
     return ret, fb


### PR DESCRIPTION
Implements databroker's pieces of
https://github.com/NSLS-II/databroker/pull/322, where Resource and
Datum docs are inserted the same as everything else.

This is designed to work with old ophyd configurations (where ophyd inserts
Resource/Datum docs directly into a Registry) running new ophyd objects (where
the RunEngine collects Resource/Datum docs and emits them). In this case, the
databroker will see two documents with the same uid, which would normally cause
it to error. To ease the transition, we the databroker will emit a warning if
it sees a duplicate insert but then just ignore it. This behavior is
configurable by a new kwarg, which is strict by default in the low-level API.
It is tolerant by default in the high-level ``Broker.insert`` API, only
temporarily to ease this transition.