### PR TITLE
CLN: remove print namespace in _core

### DIFF
--- a/databroker/_core.py
+++ b/databroker/_core.py
@@ -114,7 +114,6 @@ class Header(object):
             d['stop'] = db.prepare_hook('stop', run_stop or {})
 
         d['ext'] = SimpleNamespace(**db.fetch_external(run_start, run_stop))
-        print(d['ext'])
         h = cls(db, **d)
         return h
 


### PR DESCRIPTION
Previously observed by @tacaswell and @jrmlhermitte at ISS, found today at TES.