### PR TITLE
BLD: correct rendering of the README.md on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     packages=find_packages(),
     description='Unification of NSLS-II data sources',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     package_data={'databroker.assets': ['schemas/*.json']},
     # The project's main homepage.
     url='https://github.com/NSLS-II/databroker',


### PR DESCRIPTION
Should fix the default rst rendering at https://pypi.org/project/databroker/:
![image](https://user-images.githubusercontent.com/13209176/41854366-0e05ca66-785e-11e8-963e-1da626997bcd.png)

Attn @danielballan