### PR TITLE
Adding an `import databroker` required line

### DIFF
--- a/doc/source/creating.rst
+++ b/doc/source/creating.rst
@@ -37,6 +37,7 @@ The next step is to install a version sentinel. This is done as follows:
     db_analysis = Broker.named(config_name)
 
     # install sentinels
+    import databroker
     databroker.assets.utils.install_sentinels(db_analysis.reg.config,
                                               version=1)
 

--- a/doc/source/creating.rst
+++ b/doc/source/creating.rst
@@ -37,8 +37,7 @@ The next step is to install a version sentinel. This is done as follows:
     db_analysis = Broker.named(config_name)
 
     # install sentinels
-    import databroker
-    databroker.assets.utils.install_sentinels(db_analysis.reg.config,
+    db_analysis.assets.utils.install_sentinels(db_analysis.reg.config,
                                               version=1)
 
 where ``config_name`` is the name of your configuration and ``version=1``


### PR DESCRIPTION
This adds the line `import databroker` above the line `databroker.assets.utils.install_sentinels(db_analysis.reg.config, version=1)`
This import is required for these lines to work.